### PR TITLE
v0.2.1, parameterized knot points objectives and constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DirectTrajOpt"
 uuid = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ExponentialAction = "e24c0720-ea99-47e8-929e-571b494574d3"

--- a/src/constraints/nonlinear_constraints.jl
+++ b/src/constraints/nonlinear_constraints.jl
@@ -1,64 +1,87 @@
 export NonlinearKnotPointConstraint
 
+
 struct NonlinearKnotPointConstraint <: AbstractNonlinearConstraint
     g!::Function
     ∂g!::Function
     ∂gs::Vector{SparseMatrixCSC}
     μ∂²g!::Function
     μ∂²gs::Vector{SparseMatrixCSC}
-    equality::Bool
     times::AbstractVector{Int}
+    equality::Bool
     g_dim::Int
     dim::Int
 
     """
         NonlinearKnotPointConstraint(
             g::Function,
-            name::Symbol,
+            names::AbstractVector{Symbol},
+            traj::NamedTrajectory,
+            params::AbstractVector;
+            kwargs...
+        )
+        NonlinearKnotPointConstraint(
+            g::Function,
+            names::AbstractVector{Symbol},
             traj::NamedTrajectory;
             kwargs...
         )
+        NonlinearKnotPointConstraint(
+            g::Function,
+            name::Symbol,
+            args...;
+            kwargs...
+        )
 
-    Create a NonlinearKnotPointConstraint object that represents a nonlinear constraint on a trajectory.
+    Create a NonlinearKnotPointConstraint object that represents a nonlinear constraint `g(x,p)`
+    on a trajectory variable `x` with parameters `p`. If the parameters argument is omitted, 
+    `g(x)` is assumed to be a function of `x` only.
 
     # Arguments
-    - `g::Function`: Function that defines the constraint. If `equality=false`, the constraint is `g(x) ≤ 0`.
+    - `g::Function`: Function that defines the constraint, g(x, p) or g(x).
     - `name::Symbol`: Name of the variable to be constrained.
     - `traj::NamedTrajectory`: The trajectory on which the constraint is defined.
+    - `params::AbstractVector`: Parameters `p` for the constraint function `g`, for each time.
 
     # Keyword Arguments
-    - `equality::Bool=true`: If `true`, the constraint is `g(x) = 0`. Otherwise, the constraint is `g(x) ≤ 0`.
     - `times::AbstractVector{Int}=1:traj.T`: Time indices at which the constraint is enforced.
+    - `equality::Bool=true`: If `true`, the constraint is `g(x) = 0`. Otherwise, the constraint is `g(x) ≤ 0`.
     - `jacobian_structure::Union{Nothing, SparseMatrixCSC}=nothing`: Structure of the Jacobian matrix of the constraint.
     - `hessian_structure::Union{Nothing, SparseMatrixCSC}=nothing`: Structure of the Hessian matrix of the constraint.
     """
     function NonlinearKnotPointConstraint(
         g::Function,
-        name::Symbol,
-        traj::NamedTrajectory;
-        equality::Bool=true,
+        names::AbstractVector{Symbol},
+        traj::NamedTrajectory,
+        params::AbstractVector;
         times::AbstractVector{Int}=1:traj.T,
+        equality::Bool=true,
         jacobian_structure::Union{Nothing, SparseMatrixCSC}=nothing,
         hessian_structure::Union{Nothing, SparseMatrixCSC}=nothing,
     )
-        @assert g(traj[1][name]) isa AbstractVector{Float64}
+        @assert length(params) == length(times) "params must have the same length as times"
 
-        g_dim = length(g(traj[1][name]))
+        for name in names
+            @assert g(traj[times[1]][name], params[1]) isa AbstractVector{Float64}
+        end
+
         z_dim = traj.dim
-        x_comps = traj.components[name]
+        g_dim = sum(length(g(traj[times[1]][name], params[1])) for name in names)
+        x_comps = vcat([traj.components[name] for name in names]...)
+        x_slices = [slice(t, x_comps, traj.dim) for t in times]
 
         @views function g!(δ::AbstractVector, Z⃗::AbstractVector)
-            for (i, k) ∈ enumerate(times)
-                δ[slice(i, g_dim)] = g(Z⃗[slice(k, x_comps, z_dim)])
+            for (i, x_slice) ∈ enumerate(x_slices)
+                δ[slice(i, g_dim)] = g(Z⃗[x_slice], params[i])
             end
         end
 
         @views function ∂g!(∂gs::Vector{<:AbstractMatrix}, Z⃗::AbstractVector)
-            for (k, ∂g) ∈ zip(times, ∂gs)
+            for (i, (x_slice, ∂g)) ∈ enumerate(zip(x_slices, ∂gs))
                 ForwardDiff.jacobian!(
                     ∂g[:, x_comps], 
-                    g, 
-                    Z⃗[slice(k, x_comps, z_dim)]
+                    x -> g(x, params[i]),
+                    Z⃗[x_slice]
                 )
             end
         end
@@ -71,7 +94,7 @@ struct NonlinearKnotPointConstraint <: AbstractNonlinearConstraint
             for (i, (k, μ∂²g)) ∈ enumerate(zip(times, μ∂²gs))
                 ForwardDiff.hessian!(
                     μ∂²g[x_comps, x_comps], 
-                    Z -> μ[slice(i, g_dim)]' * g(Z), 
+                    x -> μ[slice(i, g_dim)]' * g(x, params[i]), 
                     Z⃗[slice(k, x_comps, z_dim)]
                 )
             end
@@ -101,12 +124,36 @@ struct NonlinearKnotPointConstraint <: AbstractNonlinearConstraint
             ∂gs,
             μ∂²g!,
             μ∂²gs,
-            equality,
             times,
+            equality,
             g_dim,
             g_dim * length(times)
         )
     end
+
+    function NonlinearKnotPointConstraint(
+        g::Function,
+        names::AbstractVector{Symbol},
+        traj::NamedTrajectory;
+        times::AbstractVector{Int}=1:traj.T,
+        kwargs...
+    )
+        params = [nothing for _ in times]
+        g_param = (x, _) -> g(x)
+        return NonlinearKnotPointConstraint(
+            g_param, 
+            names, 
+            traj, 
+            params; 
+            times=times, 
+            kwargs...
+        )
+    end
+
+    function NonlinearKnotPointConstraint(g::Function, name::Symbol, args...; kwargs...)
+        return NonlinearKnotPointConstraint(g, [name], args...; kwargs...)
+    end
+
 end
 
 function get_full_jacobian(
@@ -130,6 +177,8 @@ function get_full_hessian(
     end
     return μ∂²g_full
 end
+
+# ============================================================================= #
 
 @testitem "testing NonlinearConstraint" begin
 

--- a/src/constraints/nonlinear_constraints.jl
+++ b/src/constraints/nonlinear_constraints.jl
@@ -61,14 +61,12 @@ struct NonlinearKnotPointConstraint <: AbstractNonlinearConstraint
     )
         @assert length(params) == length(times) "params must have the same length as times"
 
-        for name in names
-            @assert g(traj[times[1]][name], params[1]) isa AbstractVector{Float64}
-        end
-
         z_dim = traj.dim
-        g_dim = sum(length(g(traj[times[1]][name], params[1])) for name in names)
         x_comps = vcat([traj.components[name] for name in names]...)
         x_slices = [slice(t, x_comps, traj.dim) for t in times]
+
+        @assert g(traj[times[1]].data[x_comps], params[1]) isa AbstractVector{Float64}
+        g_dim = length(g(traj[times[1]].data[x_comps], params[1]))
 
         @views function g!(δ::AbstractVector, Z⃗::AbstractVector)
             for (i, x_slice) ∈ enumerate(x_slices)

--- a/src/objectives/_objectives.jl
+++ b/src/objectives/_objectives.jl
@@ -2,8 +2,6 @@ module Objectives
 
 export Objective
 export NullObjective
-export KnotPointObjective
-export TerminalObjective
 
 using ..Constraints
 
@@ -45,6 +43,17 @@ function Base.:+(obj1::Objective, obj2::Objective)
 	return Objective(L, ∇L, ∂²L, ∂²L_structure)
 end
 
+# TODO: Unnecessary base case?
+# Base.:+(obj::Objective, ::Nothing) = obj
+# Base.:+(obj::Objective) = obj
+
+function Base.:+(num::Real, obj::Objective)
+	L = (Z⃗) -> num + obj.L(Z⃗)
+	return Objective(L, obj.∇L, obj.∂²L, obj.∂²L_structure)
+end
+
+Base.:+(obj::Objective, num::Real) = num + obj
+
 function Base.:*(num::Real, obj::Objective)
 	L = (Z⃗) -> num * obj.L(Z⃗)
 	∇L = (Z⃗) -> num * obj.∇L(Z⃗)
@@ -54,9 +63,6 @@ end
 
 Base.:*(obj::Objective, num::Real) = num * obj
 
-# TODO: Unnecessary?
-# Base.:+(obj::Objective, ::Nothing) = obj
-# Base.:+(obj::Objective) = obj
 
 # ----------------------------------------------------------------------------- #
 # Null objective                                      
@@ -71,85 +77,11 @@ function NullObjective(Z::NamedTrajectory)
 end
 
 # ----------------------------------------------------------------------------- #
-# Knot Point objective
-# ----------------------------------------------------------------------------- #
-
-function KnotPointObjective(
-    ℓ::Function,
-    name::Symbol,
-    traj::NamedTrajectory;
-    Qs::AbstractVector{Float64}=ones(traj.T),
-    times::AbstractVector{Int}=1:traj.T,
-)
-    @assert length(Qs) == length(times) "Qs must have the same length as times"
-
-    Z_dim = traj.dim * traj.T + traj.global_dim
-    x_slices = [slice(t, traj.components[name], traj.dim) for t in times]
-    
-    function L(Z⃗::AbstractVector{<:Real})
-        loss = 0.0
-        for (i, x_slice) in enumerate(x_slices)
-            x = Z⃗[x_slice]
-            loss += Qs[i] * ℓ(x)
-        end
-        return loss
-    end
-
-    @views function ∇L(Z⃗::AbstractVector{<:Real})
-        ∇ = zeros(Z_dim)
-        for (i, x_slice) in enumerate(x_slices)
-            x = Z⃗[x_slice]
-            ∇[x_slice] = ForwardDiff.gradient(x -> Qs[i] * ℓ(x), x)
-        end
-        return ∇
-    end
-
-    function ∂²L_structure()
-        structure = spzeros(Z_dim, Z_dim)
-        for x_slice in x_slices
-            structure[x_slice, x_slice] .= 1.0
-        end
-        structure_pairs = collect(zip(findnz(structure)[1:2]...))
-        return structure_pairs
-    end
-
-    @views function ∂²L(Z⃗::AbstractVector{<:Real})
-        ∂²L_values = zeros(length(∂²L_structure()))
-        for (i, x_slice) in enumerate(x_slices)
-            ∂²ℓ = ForwardDiff.hessian(x -> Qs[i] * ℓ(x), Z⃗[x_slice])
-            ∂²ℓ_length = length(∂²ℓ[:])
-            ∂²L_values[(i - 1) * ∂²ℓ_length + 1:i * ∂²ℓ_length] = ∂²ℓ[:]
-        end
-        return ∂²L_values
-    end
-
-    return Objective(L, ∇L, ∂²L, ∂²L_structure)
-end
-
-function TerminalObjective(
-    ℓ::Function,
-    name::Symbol,
-    traj::NamedTrajectory;
-    Q::Float64=1.0
-)
-    return KnotPointObjective(
-        ℓ,
-        name,
-        traj;
-        Qs=[Q],
-        times=[traj.T]
-    )
-end
-
-# ----------------------------------------------------------------------------- #
 # Additional objectives
 # ----------------------------------------------------------------------------- #
 
+include("knot_point_objectives.jl")
 include("minimum_time_objective.jl")
 include("regularizers.jl")
-
-# =========================================================================== #
-
-# TODO: Testing (see constraints)
 
 end

--- a/src/objectives/knot_point_objectives.jl
+++ b/src/objectives/knot_point_objectives.jl
@@ -1,0 +1,190 @@
+export KnotPointObjective
+export TerminalObjective
+
+"""
+    KnotPointObjective(
+        ℓ::Function,
+        names::AbstractVector{Symbol},
+        traj::NamedTrajectory,
+        params::AbstractVector;
+        kwargs...
+    )
+    KnotPointObjective(
+        ℓ::Function,
+        names::AbstractVector{Symbol},
+        traj::NamedTrajectory;
+        kwargs...
+    )
+    KnotPointObjective(
+        ℓ::Function,
+        name::Symbol,
+        args...;
+        kwargs...
+    )
+
+Create a knot point summed objective function for trajectory optimization, where `ℓ(x, p)` 
+on trajectory knot point variables `x` with parameters `p`. If the parameters argument is 
+omitted, `ℓ(x)` is assumed  to be a function of `x` only.
+
+# Arguments
+- `ℓ::Function`: Function that defines the objective, ℓ(x, p) or ℓ(x).
+- `names::AbstractVector{Symbol}`: Names of the trajectory variables to be optimized.
+- `traj::NamedTrajectory`: The trajectory on which the objective is defined.
+- `params::AbstractVector`: Parameters `p` for the objective function ℓ, for each time.
+
+# Keyword Arguments
+- `times::AbstractVector{Int}=1:traj.T`: Time indices at which the objective is evaluated.
+- `Qs::AbstractVector{Float64}=ones(traj.T)`: Weights for the objective function at each time.
+"""
+function KnotPointObjective(
+    ℓ::Function,
+    names::AbstractVector{Symbol},
+    traj::NamedTrajectory,
+    params::AbstractVector;
+    times::AbstractVector{Int}=1:traj.T,
+    Qs::AbstractVector{Float64}=ones(traj.T),
+)
+    @assert length(Qs) == length(times) "Qs must have the same length as times"
+    @assert length(params) == length(times) "params must have the same length as times"
+
+    Z_dim = traj.dim * traj.T + traj.global_dim
+    x_comps = vcat([traj.components[name] for name in names]...)
+    x_slices = [slice(t, x_comps, traj.dim) for t in times]
+    
+    function L(Z⃗::AbstractVector{<:Real})
+        loss = 0.0
+        for (i, x_slice) in enumerate(x_slices)
+            x = Z⃗[x_slice]
+            loss += Qs[i] * ℓ(x, params[i])
+        end
+        return loss
+    end
+
+    @views function ∇L(Z⃗::AbstractVector{<:Real})
+        ∇ = zeros(Z_dim)
+        for (i, x_slice) in enumerate(x_slices)
+            x = Z⃗[x_slice]
+            ∇[x_slice] = ForwardDiff.gradient(x -> Qs[i] * ℓ(x, params[i]), x)
+        end
+        return ∇
+    end
+
+    function ∂²L_structure()
+        structure = spzeros(Z_dim, Z_dim)
+        for x_slice in x_slices
+            structure[x_slice, x_slice] .= 1.0
+        end
+        structure_pairs = collect(zip(findnz(structure)[1:2]...))
+        return structure_pairs
+    end
+
+    @views function ∂²L(Z⃗::AbstractVector{<:Real})
+        ∂²L_values = zeros(length(∂²L_structure()))
+        for (i, x_slice) in enumerate(x_slices)
+            ∂²ℓ = ForwardDiff.hessian(x -> Qs[i] * ℓ(x, params[i]), Z⃗[x_slice])
+            ∂²ℓ_length = length(∂²ℓ[:])
+            ∂²L_values[(i - 1) * ∂²ℓ_length + 1:i * ∂²ℓ_length] = ∂²ℓ[:]
+        end
+        return ∂²L_values
+    end
+
+    return Objective(L, ∇L, ∂²L, ∂²L_structure)
+end
+
+function KnotPointObjective(
+    ℓ::Function,
+    names::AbstractVector{Symbol},
+    traj::NamedTrajectory;
+    times::AbstractVector{Int}=1:traj.T,
+    kwargs...
+)
+    params = [nothing for _ in times]
+    ℓ_param = (x, _) -> ℓ(x)
+    return KnotPointObjective(ℓ_param, names, traj, params; times=times, kwargs...)
+end
+
+function KnotPointObjective(ℓ::Function,  name::Symbol,  args...;  kwargs...)
+    return KnotPointObjective(ℓ, [name], args...; kwargs...)
+end
+
+function TerminalObjective(
+    ℓ::Function,
+    name::Symbol,
+    traj::NamedTrajectory;
+    Q::Float64=1.0
+)
+    return KnotPointObjective(
+        ℓ,
+        name,
+        traj;
+        Qs=[Q],
+        times=[traj.T]
+    )
+end
+
+# ============================================================================ #
+
+@testitem "testing KnotPointObjective" begin
+
+    using TrajectoryIndexingUtils
+    
+    include("../../test/test_utils.jl")
+
+    _, traj = bilinear_dynamics_and_trajectory()
+
+    L(a) = norm(a)
+
+    Qs = [1.0, 2.0]
+    times = [1, traj.T]
+
+    OBJ = KnotPointObjective(L, :u, traj, times=times, Qs=Qs)
+
+    L̂(Z⃗) = sum(Q * L(Z⃗[slice(k, traj.components[:u], traj.dim)]) for (Q, k) ∈ zip(Qs, times))
+
+    @test OBJ.L(traj.datavec) ≈ L̂(traj.datavec)
+    
+    ∂L_autodiff = ForwardDiff.gradient(L̂, traj.datavec)
+    @test OBJ.∇L(traj.datavec) ≈ ∂L_autodiff
+
+    ∂²L_autodiff = ForwardDiff.hessian(L̂, traj.datavec)
+
+    ∂²L_full = zeros(size(∂²L_autodiff))
+    for (index, entry) in zip(OBJ.∂²L_structure(), OBJ.∂²L(traj.datavec))
+        i, j = index
+        ∂²L_full[i, j] = entry
+    end
+
+    @test ∂²L_full ≈ ∂²L_autodiff
+end
+
+@testitem "testing KnotPointObjective with parameters" begin
+
+    using TrajectoryIndexingUtils
+    
+    include("../../test/test_utils.jl")
+
+    _, traj = bilinear_dynamics_and_trajectory()
+
+    L(x, p) = norm(x) + p
+
+    Qs = [1.0, 2.0]
+    times = [1, traj.T]
+    params = [1.0, 2.0]
+
+    OBJ = KnotPointObjective(L, :u, traj, params; times=times, Qs=Qs)
+
+    L̂(Z⃗) = sum(Q * L(Z⃗[slice(k, traj.components[:u], traj.dim)], p) for (Q, k, p) ∈ zip(Qs, times, params))
+
+    @test OBJ.L(traj.datavec) ≈ L̂(traj.datavec)
+    
+    ∂L_autodiff = ForwardDiff.gradient(L̂, traj.datavec)
+    @test OBJ.∇L(traj.datavec) ≈ ∂L_autodiff
+
+    ∂²L_autodiff = ForwardDiff.hessian(L̂, traj.datavec)
+    ∂²L_full = zeros(size(∂²L_autodiff))
+    for (index, entry) in zip(OBJ.∂²L_structure(), OBJ.∂²L(traj.datavec))
+        i, j = index
+        ∂²L_full[i, j] = entry
+    end
+    @test ∂²L_full ≈ ∂²L_autodiff
+end


### PR DESCRIPTION
It is useful to pass g(x, p) and L(x, p) with parameters. This wraps the previous knot point constructors with the ability to pass parameterized losses and constraints.

We avoid passing vectors of functions and stick with the single function call. No breaking changes with prev. interface.