### PR TITLE
Fix: sync derived IpoptOptions fields from solve! kwargs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DirectTrajOpt"
 uuid = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]

--- a/src/solvers/ipopt_solver/solver.jl
+++ b/src/solvers/ipopt_solver/solver.jl
@@ -76,7 +76,8 @@ function DTO.Solvers.solve!(
         options.hessian_approximation = options.eval_hessian ? "exact" : "limited-memory"
     end
     if haskey(kwargs, :refine) && !haskey(kwargs, :adaptive_mu_globalization)
-        options.adaptive_mu_globalization = options.refine ? "obj-constr-filter" : "never-monotone-mode"
+        options.adaptive_mu_globalization =
+            options.refine ? "obj-constr-filter" : "never-monotone-mode"
     end
 
     optimizer, variables =
@@ -545,15 +546,15 @@ end
     @test opts2.hessian_approximation == "exact"
 
     # IpoptOptions constructor correctly computes derived field
-    opts3 = IpoptOptions(eval_hessian=false)
+    opts3 = IpoptOptions(eval_hessian = false)
     @test opts3.hessian_approximation == "limited-memory"
 
     # refine → adaptive_mu_globalization
-    opts4 = IpoptOptions(refine=false)
+    opts4 = IpoptOptions(refine = false)
     @test opts4.adaptive_mu_globalization == "never-monotone-mode"
 
     # Explicit override takes precedence over sync
-    opts5 = IpoptOptions(eval_hessian=false, hessian_approximation="exact")
+    opts5 = IpoptOptions(eval_hessian = false, hessian_approximation = "exact")
     @test opts5.hessian_approximation == "exact"
 
     # End-to-end: solve! with eval_hessian=false kwarg should use L-BFGS
@@ -567,5 +568,5 @@ end
     J += QuadraticRegularizer(:u, traj, 1.0)
     J += MinimumTimeObjective(traj)
     prob = DirectTrajOptProblem(traj, J, integrators)
-    solve!(prob; max_iter=5, eval_hessian=false, print_level=0)
+    solve!(prob; max_iter = 5, eval_hessian = false, print_level = 0)
 end


### PR DESCRIPTION
## Summary

- When `eval_hessian=false` was passed as a kwarg to `solve!`, the derived `hessian_approximation` field stayed at its default `"exact"` because it was computed at `IpoptOptions` construction time. This caused Ipopt to silently error (`"eval_h returns false"`) and skip optimization entirely.
- After the kwargs loop in `solve!`, derived fields are now synced: `eval_hessian` → `hessian_approximation` and `refine` → `adaptive_mu_globalization`. Explicit overrides still take precedence.

## Test plan

- [x] All 222 existing tests pass
- [x] New test item verifies derived field sync for both `eval_hessian` and `refine`
- [x] End-to-end test: `solve!(prob; eval_hessian=false)` no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)