### PR TITLE
feat: per-timestep EqualityConstraint and fix_trajectory_variable!

### DIFF
--- a/src/constraints/linear/equality_constraint.jl
+++ b/src/constraints/linear/equality_constraint.jl
@@ -14,14 +14,14 @@ Indices are computed when constraint is applied in constrain!.
 # Fields
 - `var_names::Union{Symbol, Vector{Symbol}}`: Variable name(s) to constrain
 - `times::Union{Nothing, Vector{Int}}`: Time indices (nothing for global variables)
-- `values::Vector{Float64}`: Constraint values
+- `values::Union{Vector{Float64}, Matrix{Float64}}`: Constraint values (Vector for uniform, Matrix for per-timestep)
 - `is_global::Bool`: Whether this is a global variable constraint
 - `label::String`: Constraint label
 """
 struct EqualityConstraint <: AbstractLinearConstraint
     var_names::Union{Symbol,Vector{Symbol}}
     times::Union{Nothing,Vector{Int}}
-    values::Vector{Float64}
+    values::Union{Vector{Float64},Matrix{Float64}}
     is_global::Bool
     label::String
 end
@@ -80,6 +80,67 @@ function GlobalEqualityConstraint(
         true,  # is global
         label,
     )
+end
+
+"""
+    EqualityConstraint(
+        name::Symbol,
+        ts::AbstractVector{Int},
+        val::Matrix{Float64};
+        label="per-timestep equality constraint on trajectory variable \$name"
+    )
+
+Constructs a per-timestep equality constraint for a trajectory variable.
+`val` must have size `(var_dim, length(ts))` — column `k` pins the variable
+at timestep `ts[k]`.
+"""
+function EqualityConstraint(
+    name::Symbol,
+    ts::AbstractVector{Int},
+    val::AbstractMatrix{Float64};
+    label = "per-timestep equality constraint on trajectory variable $name",
+)
+    @assert size(val, 2) == length(ts) (
+        "Matrix columns ($(size(val, 2))) must match number of timesteps ($(length(ts)))"
+    )
+    return EqualityConstraint(name, collect(ts), Matrix(val), false, label)
+end
+
+export fix_trajectory_variable!
+
+"""
+    fix_trajectory_variable!(constraints, name, values; times)
+
+Pin a trajectory variable to per-timestep values using an `EqualityConstraint`.
+Removes any existing `BoundsConstraint` on `name` to avoid MOI conflicts.
+
+# Arguments
+- `constraints::Vector{<:AbstractConstraint}`: mutable constraint list
+- `name::Symbol`: trajectory variable name to pin
+- `values::AbstractMatrix{Float64}`: size `(var_dim, N)` — column `k` pins timestep `k`
+
+# Keyword Arguments
+- `times::AbstractVector{Int}`: timesteps to pin (default: `1:size(values, 2)`)
+"""
+function fix_trajectory_variable!(
+    constraints::Vector{<:AbstractConstraint},
+    name::Symbol,
+    values::AbstractMatrix{Float64};
+    times::AbstractVector{Int} = 1:size(values, 2),
+)
+    # Remove existing BoundsConstraint and EqualityConstraint on this trajectory variable
+    # to avoid MOI conflicts (per-timestep pinning supersedes initial/final/bounds)
+    filter!(constraints) do c
+        if c isa BoundsConstraint && c.var_names == name && !c.is_global
+            return false
+        elseif c isa EqualityConstraint && c.var_names == name && !c.is_global
+            return false
+        end
+        return true
+    end
+    # Add per-timestep equality constraint
+    push!(constraints, EqualityConstraint(name, times, values))
+    return constraints
 end
 
 function Base.show(io::IO, c::EqualityConstraint)
@@ -164,4 +225,78 @@ end
     # Verify global constraint is satisfied
     g_components = traj.global_components[:g]
     @test prob.trajectory.global_data[g_components] ≈ g_value atol=1e-6
+end
+
+@testitem "EqualityConstraint - per-timestep matrix values" begin
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory()
+
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    # Pin du at timesteps 3:7 to per-timestep values
+    du_dim = traj.dims[:du]
+    pin_times = 3:7
+    du_ref = randn(du_dim, length(pin_times))
+    pin_con = EqualityConstraint(:du, collect(pin_times), du_ref)
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [pin_con])
+    solve!(prob; max_iter = 100)
+
+    # Verify: pinned values are exactly recovered
+    for (k, t) in enumerate(pin_times)
+        @test prob.trajectory[t][:du] ≈ du_ref[:, k] atol=1e-8
+    end
+end
+
+@testitem "fix_trajectory_variable! removes bounds and pins values" begin
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory()
+
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:ddu, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    # Build a normal problem first (generates initial/final/bounds constraints)
+    prob_orig = DirectTrajOptProblem(traj, J, integrators)
+
+    # Verify bounds and initial equality exist on :u before fixing
+    @test any(c -> c isa BoundsConstraint && c.var_names == :u, prob_orig.constraints)
+    @test any(c -> c isa EqualityConstraint && c.var_names == :u, prob_orig.constraints)
+
+    # Fix u to per-timestep values (should remove bounds AND initial/final equality)
+    u_ref = copy(traj[:u])
+    constraints = deepcopy(prob_orig.constraints)
+    fix_trajectory_variable!(constraints, :u, u_ref)
+
+    # Old bounds and equality constraints on :u should be removed
+    @test !any(c -> c isa BoundsConstraint && c.var_names == :u, constraints)
+    # Only the new per-timestep equality should remain
+    u_eq_cons = filter(c -> c isa EqualityConstraint && c.var_names == :u, constraints)
+    @test length(u_eq_cons) == 1
+    @test u_eq_cons[1].values isa Matrix{Float64}
+
+    # Solve with 4-arg constructor (no double-adding trajectory constraints)
+    prob = DirectTrajOptProblem(traj, J, integrators, constraints)
+    solve!(prob; max_iter = 100)
+
+    # Pinned values should have zero drift
+    for t in 1:traj.N
+        @test prob.trajectory[t][:u] ≈ u_ref[:, t] atol=1e-10
+    end
 end

--- a/src/constraints/linear/equality_constraint.jl
+++ b/src/constraints/linear/equality_constraint.jl
@@ -296,7 +296,7 @@ end
     solve!(prob; max_iter = 100)
 
     # Pinned values should have zero drift
-    for t in 1:traj.N
+    for t = 1:traj.N
         @test prob.trajectory[t][:u] ≈ u_ref[:, t] atol=1e-10
     end
 end

--- a/src/solvers/ipopt_solver/constraints.jl
+++ b/src/solvers/ipopt_solver/constraints.jl
@@ -37,19 +37,31 @@ function (con::EqualityConstraint)(
         @assert name ∈ traj.names "Variable $name not found in trajectory"
         ts = con.times
 
-        # Handle scalar value - repeat for variable dimension
-        if length(con.values) == 1
-            val_per_time = fill(con.values[1], traj.dims[name])
+        if con.values isa Matrix{Float64}
+            # Per-timestep values: column k → timestep ts[k]
+            @assert size(con.values, 1) == traj.dims[name] (
+                "Matrix row dimension ($(size(con.values, 1))) must match variable dimension ($(traj.dims[name])) for $name"
+            )
+            for (k, t) ∈ enumerate(ts)
+                indices = slice(t, traj.components[name], traj.dim)
+                for (i, val) ∈ zip(indices, @view con.values[:, k])
+                    MOI.add_constraints(opt, vars[i], MOI.EqualTo(val))
+                end
+            end
         else
-            @assert length(con.values) == traj.dims[name] "Value dimension mismatch for variable $name"
-            val_per_time = con.values
-        end
+            # Uniform values (existing behavior)
+            if length(con.values) == 1
+                val_per_time = fill(con.values[1], traj.dims[name])
+            else
+                @assert length(con.values) == traj.dims[name] "Value dimension mismatch for variable $name"
+                val_per_time = con.values
+            end
 
-        # Apply constraint at each time step
-        for t ∈ ts
-            indices = slice(t, traj.components[name], traj.dim)
-            for (i, val) ∈ zip(indices, val_per_time)
-                MOI.add_constraints(opt, vars[i], MOI.EqualTo(val))
+            for t ∈ ts
+                indices = slice(t, traj.components[name], traj.dim)
+                for (i, val) ∈ zip(indices, val_per_time)
+                    MOI.add_constraints(opt, vars[i], MOI.EqualTo(val))
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary

- **Per-timestep `EqualityConstraint`**: extends the existing equality constraint to support pinning individual trajectory variables at specific timesteps
- **`fix_trajectory_variable!` helper**: convenience function for fixing trajectory variables during optimization (used by Intonato.jl's alternating calibration to pin pulse variables during parameter estimation)

## Test plan
- [ ] CI passes on all existing tests
- [ ] Per-timestep equality constraints correctly enforce values at specified timesteps
- [ ] `fix_trajectory_variable!` correctly pins variables in the constraint set

🤖 Generated with [Claude Code](https://claude.com/claude-code)