### PR TITLE
Version bump to v0.9.2; add back in previously removed support for SciMLBase v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DirectTrajOpt"
 uuid = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]
@@ -43,7 +43,7 @@ NamedTrajectories = "0.8"
 OrdinaryDiffEqTsit5 = "1.9, 2"
 Random = "1.10, 1.11, 1.12"
 Reexport = "1.2"
-SciMLBase = "3"
+SciMLBase = "2.148, 3"
 SparseArrays = "1.10, 1.11, 1.12"
 Test = "1.10, 1.11, 1.12"
 TestItemRunner = "1.1"


### PR DESCRIPTION
Add back in previously removed support for SciMLBase v2 (alongside OrdinaryDiffEq v6, which was never removed), to prevent upstream havoc with QuantumToolbox compat