### PR TITLE
chore: bump version to 0.9.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DirectTrajOpt"
 uuid = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

Patch release including the new `fix_global_variable!` public API merged via #82.

## Why a patch (0.9.2 → 0.9.3) and not a minor bump

The change is purely additive (one new exported function); no breaking API change. Pre-1.0, the convention in this repo is to ship feature-additive PRs as patches under the same 0.9.x line (cf. #80, #81). This also keeps Piccolo's existing compat (`DirectTrajOpt = "0.8, 0.9"`) working without a coordinated bump.

## Unblocks

[harmoniqs/Piccolo.jl#178](https://github.com/harmoniqs/Piccolo.jl/pull/178) (`feat: add calibration_targets kwarg to pulse problem templates`) depends on `fix_global_variable!` being available in a registered DTO version.

## After merge

`@JuliaRegistrator register()` to publish.