### PR TITLE
solver(ipopt): bump diverging_iterates_tol default 1e8 → 1e20

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DirectTrajOpt"
 uuid = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]

--- a/src/solvers/ipopt_solver/options.jl
+++ b/src/solvers/ipopt_solver/options.jl
@@ -44,7 +44,11 @@ Base.@kwdef mutable struct IpoptOptions <: Solvers.AbstractSolverOptions
     acceptable_constr_viol_tol::Float64 = 1.0e-2
     acceptable_compl_inf_tol::Float64 = 1.0e-2
     acceptable_obj_change_tol::Float64 = 1.0e-5
-    diverging_iterates_tol::Float64 = 1.0e8
+    # Ipopt's default is 1e20; the previous 1e8 fired false-positive "Iterates
+    # diverging" exits on smooth-pulse NLPs whose unscaled second derivatives
+    # legitimately reach O(1e8) (e.g. ddu ≈ u_max / Δt² with Δt in ns).
+    # Until DTO-level variable scaling lands, defer to Ipopt's default.
+    diverging_iterates_tol::Float64 = 1.0e20
     eval_hessian = true
     hessian_approximation = eval_hessian ? "exact" : "limited-memory"
     hsllib = nothing
@@ -69,4 +73,11 @@ Base.@kwdef mutable struct IpoptOptions <: Solvers.AbstractSolverOptions
     recalc_y_feas_tol = 1.0e-6
     watchdog_shortened_iter_trigger = 0
     watchdog_trial_iter_max = 3
+end
+
+@testitem "IpoptOptions: diverging_iterates_tol default matches Ipopt" begin
+    using DirectTrajOpt: IpoptSolverExt
+    # Locks in the bump from 1e8 (false-positive on smooth-pulse NLPs) to Ipopt's
+    # native default of 1e20. See hopper/dto-variable-scaling for context.
+    @test IpoptSolverExt.IpoptOptions().diverging_iterates_tol == 1.0e20
 end


### PR DESCRIPTION
## Summary

- Bump `IpoptOptions.diverging_iterates_tol` default from `1e8` to Ipopt's native `1e20`.
- Adds a regression testitem locking the new default in.

## Why

The old `1e8` fired false-positive `EXIT: Iterates diverging; problem might be unbounded` on well-posed smooth-pulse NLPs whose unscaled second derivatives legitimately reach O(1e8). Concretely, with $u_\max \approx 628$ rad/μs and $\Delta t \approx 2.5$ ns:

$$
\ddot u \approx \frac{u_\max}{\Delta t^2} \approx 1.6 \times 10^8
$$

From the cryoCMOS spin S5 demo (2026-04-21):

| Run | Threshold | Exit | F | T | Iters |
|-----|-----------|------|---|---|-------|
| S5 exact-Hessian | 1e8 (default) | diverging @ 137 | 0.929 | 101 ns | 137 |
| S5 (1-F)² exact | 1e8 (default) | diverging @ 164 | 0.928 | 119 ns | 164 |
| S5b refine + tol=1e20 | 1e20 | **Optimal** | 0.929 | 95 ns | 113 |

Same problem, same warm start — only the threshold differs. The first two exited with a false "diverging" label; the last actually converged.

## Tradeoffs

- This silences the diagnostic until DTO-level variable scaling lands. Setting `diverging_iterates_tol = 1e20` in the unscaled space means the only iterates that will trip it are the genuinely insane ones.
- The principled fix is auto-scaling NLP variables so the unscaled magnitude is O(1) and the threshold becomes meaningful again. Tracked in `vault/hopper/dto-variable-scaling.md` (Step 1 of the roadmap is this PR; Step 2 is the scaling implementation; Step 3 flips opt-out and the threshold default stops mattering).
- Users who want the old behaviour can still pass `diverging_iterates_tol = 1e8` explicitly.

## Test plan

- [ ] `Pkg.test()` green
- [ ] New testitem `IpoptOptions: diverging_iterates_tol default matches Ipopt` passes
- [ ] No regression in existing solver/options testitems

## Draft

Opening as draft for morning review — happy to land or adjust scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)