### PR TITLE
fix: address Aqua and JET findings

### DIFF
--- a/src/constraints/linear/bounds_constraint.jl
+++ b/src/constraints/linear/bounds_constraint.jl
@@ -12,7 +12,7 @@ Represents a box constraint defined by variable names.
 Indices and concrete bounds are computed in constrain!.
 
 # Fields
-- `var_names::Union{Symbol, Vector{Symbol}}`: Variable name(s) to constrain
+- `var_names::Symbol`: Variable name to constrain
 - `times::Union{Nothing, Vector{Int}}`: Time indices (nothing for global variables)
 - `bounds_values::Union{Float64, Vector{Float64}, Tuple{Vector{Float64}, Vector{Float64}}}`: Bound specification
 - `is_global::Bool`: Whether this is a global variable constraint
@@ -20,7 +20,7 @@ Indices and concrete bounds are computed in constrain!.
 - `label::String`: Constraint label
 """
 struct BoundsConstraint <: AbstractLinearConstraint
-    var_names::Union{Symbol,Vector{Symbol}}
+    var_names::Symbol
     times::Union{Nothing,Vector{Int}}
     bounds_values::Union{Float64,Vector{Float64},Tuple{Vector{Float64},Vector{Float64}}}
     is_global::Bool

--- a/src/constraints/linear/equality_constraint.jl
+++ b/src/constraints/linear/equality_constraint.jl
@@ -12,14 +12,14 @@ Represents a linear equality constraint defined by variable names.
 Indices are computed when constraint is applied in constrain!.
 
 # Fields
-- `var_names::Union{Symbol, Vector{Symbol}}`: Variable name(s) to constrain
+- `var_names::Symbol`: Variable name to constrain
 - `times::Union{Nothing, Vector{Int}}`: Time indices (nothing for global variables)
 - `values::Union{Vector{Float64}, Matrix{Float64}}`: Constraint values (Vector for uniform, Matrix for per-timestep)
 - `is_global::Bool`: Whether this is a global variable constraint
 - `label::String`: Constraint label
 """
 struct EqualityConstraint <: AbstractLinearConstraint
-    var_names::Union{Symbol,Vector{Symbol}}
+    var_names::Symbol
     times::Union{Nothing,Vector{Int}}
     values::Union{Vector{Float64},Matrix{Float64}}
     is_global::Bool

--- a/src/solvers/constrain.jl
+++ b/src/solvers/constrain.jl
@@ -42,7 +42,14 @@ function (con::EqualityConstraint)(
     else
         # Trajectory variable constraint
         @assert name ∈ traj.names "Variable $name not found in trajectory"
+        # Narrow `ts` from Union{Nothing, Vector{Int}}. In the not-global branch
+        # `times` is always a Vector{Int} (set by the trajectory-variable
+        # constructors); the explicit `=== nothing` branch lets JET prove that
+        # the surviving binding is `Vector{Int}` without flagging the impossible
+        # `convert(Vector{Int}, Nothing)` path that a bare type assert produces.
         ts = con.times
+        ts === nothing &&
+            error("EqualityConstraint: times must be set for a non-global variable")
 
         if con.values isa Matrix{Float64}
             # Per-timestep values: column k → timestep ts[k]
@@ -113,6 +120,8 @@ function (con::BoundsConstraint)(
         # Trajectory variable constraint
         @assert name ∈ traj.names "Variable $name not found in trajectory"
         ts = con.times
+        ts === nothing &&
+            error("BoundsConstraint: times must be set for a non-global variable")
         var_dim = traj.dims[name]
 
         # Determine subcomponents to constrain

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -8,14 +8,7 @@
 @testitem "JET correctness analysis" tags=[:jet] begin
     if VERSION >= v"1.12"
         using JET, DirectTrajOpt
-        # Findings as of initial wiring (DirectTrajOpt v0.9.3, JET 0.11):
-        # 18 findings dominated by:
-        #   - `show_diffs(::SparseVector, ::Any)` no-matching-method when the
-        #     sparse-Jacobian union-split lands on the SparseVector branch.
-        #   - `randn(::Int64, ::NTuple{N,Int64})` test-utility helper that
-        #     forwards a tuple as the trailing dim argument.
-        # TODO: address in a follow-up PR; drop `broken = true` once clean.
-        JET.test_package(DirectTrajOpt; target_modules = (DirectTrajOpt,), broken = true)
+        JET.test_package(DirectTrajOpt; target_modules = (DirectTrajOpt,))
     else
         @info "Skipping JET correctness analysis on Julia $VERSION (requires >= 1.12)"
         @test true

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -30,13 +30,13 @@ function dense(vals, structure, shape)
 end
 
 """
-    show_diffs(A::Matrix, B::Matrix)
+    show_diffs(A, B)
 
-Show differences between matrices.
+Show differences between two arrays of the same shape (matrix or vector).
 """
-function show_diffs(A::AbstractMatrix, B::AbstractMatrix; kwargs...)
+function show_diffs(A::AbstractVecOrMat, B::AbstractVecOrMat; kwargs...)
     @assert size(A) == size(B)
-    matrix_is_square = size(A, 1) == size(A, 2)
+    matrix_is_square = ndims(A) == 2 && size(A, 1) == size(A, 2)
     for (i, (a, b)) in enumerate(zip(A, B))
         inds = Tuple(CartesianIndices(A)[i])
         if matrix_is_square
@@ -115,12 +115,12 @@ function named_trajectory_type_1(; free_time = true)
 end
 
 function bilinear_dynamics_and_trajectory(;
-    N = 10,
-    Δt = 0.1,
-    u_bound = 0.1,
-    ω = 0.1,
-    add_time = false,
-    add_global = false,
+    N::Int = 10,
+    Δt::Float64 = 0.1,
+    u_bound::Float64 = 0.1,
+    ω::Float64 = 0.1,
+    add_time::Bool = false,
+    add_global::Bool = false,
 )
     Gx = sparse(Float64[
         0 0 0 1;


### PR DESCRIPTION
## Summary

Clear all 18 JET findings from #87. The lone Aqua finding
(`hessian_structure` exported by both `CommonInterface` and
`Objectives`) stays held as \`broken = true\` per #87's TODO — that's
a structural call about which module owns the canonical
\`hessian_structure\`, better as a focused follow-up.

## JET (18 → 0)

- **13** findings traced to \`EqualityConstraint.var_names\` and
  \`BoundsConstraint.var_names\` being typed
  \`Union{Symbol, Vector{Symbol}}\` while the implementations in
  \`solvers/constrain.jl\` only ever support \`Symbol\`. The
  \`Vector{Symbol}\` branch caused \`traj.components[name]\` /
  \`traj.dims[name]\` to be inferred as
  \`Union{UnitRange, NamedTuple}\` / \`Union{Int, NamedTuple}\`, which
  cascaded into no-matching-method findings on \`slice\`, \`fill\`, \`:\`,
  and \`getindex\`. Tighten both struct fields to \`Symbol\`. None of
  the in-tree constructors ever build a \`Vector{Symbol}\` constraint,
  so this is not a behavior change.

- **3** \`iterate(::Nothing)\` findings from
  \`ts::Union{Nothing, Vector{Int}}\`. Add an explicit
  \`ts === nothing && error(...)\` guard right after the not-global
  branch entry; Julia (and JET) narrow \`ts\` to \`Vector{Int}\` for
  the rest of the function. A bare \`ts::Vector{Int} = con.times\`
  type-assert still trips JET on the impossible
  \`convert(Vector{Int}, Nothing)\` path, which the structural guard
  avoids.

- **1** \`randn(::Int64, ::NTuple{N,Int64})\` in
  \`bilinear_dynamics_and_trajectory\` (test util). Kwarg
  \`N = 10\` was inferred as \`Any\`. Annotate kwargs with concrete
  types (\`N::Int\`, \`Δt::Float64\`, etc.).

- **1** \`show_diffs(::SparseVector, ::Any)\` no-matching-method.
  Loosen \`show_diffs\` parameter type from \`AbstractMatrix\` to
  \`AbstractVecOrMat\` and gate the square-matrix branch on
  \`ndims(A) == 2\`.

JET test drops \`broken = true\` since \`report_package\` reports
zero findings — leaving it would now surface as "Unexpected Pass".

## Test plan

- [x] \`Pkg.test()\` green: 352 pass / 1 broken (the expected \`hessian_structure\`)
- [x] \`Aqua.test_all\` 9 pass / 1 broken
- [x] \`JET.report_package\` "No errors detected"
- [ ] CI green on Julia 1.10 / 1.11 / 1.12 + Documentation + Formatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)