### PR TITLE
feat(ipopt): expose bound_push, mu_init, warm_start options

### DIFF
--- a/src/solvers/ipopt_solver/options.jl
+++ b/src/solvers/ipopt_solver/options.jl
@@ -54,6 +54,17 @@ Base.@kwdef mutable struct IpoptOptions <: Solvers.AbstractSolverOptions
     refine = true
     adaptive_mu_globalization = refine ? "obj-constr-filter" : "never-monotone-mode"
     mu_target::Float64 = 1.0e-4
+    mu_init::Float64 = 0.1
+    bound_push::Float64 = 0.01
+    bound_frac::Float64 = 0.01
+    slack_bound_push::Float64 = 0.01
+    slack_bound_frac::Float64 = 0.01
+    warm_start_init_point = "no"
+    warm_start_bound_push::Float64 = 1.0e-3
+    warm_start_bound_frac::Float64 = 1.0e-3
+    warm_start_slack_bound_push::Float64 = 1.0e-3
+    warm_start_slack_bound_frac::Float64 = 1.0e-3
+    warm_start_mult_bound_push::Float64 = 1.0e-3
     nlp_scaling_method = "gradient-based"
     output_file = nothing
     print_level::Int = 5


### PR DESCRIPTION
## Summary
- Add 11 Ipopt initialization options to `IpoptOptions`: `mu_init`, `bound_push`, `bound_frac`, `slack_bound_push`, `slack_bound_frac`, and the six `warm_start_*` variants.
- All wired through `set_options!` automatically via the existing `fieldnames`-iteration pattern (no logic changes; option names match Ipopt's native names).

## Motivation
Default `bound_push = 0.01` shifts equality-constrained variables (e.g. `ψ̃[1,1] = 1.0` initial-state boundary equalities) off their bound at warm-start, creating ≈ 1e-2 initial primal infeasibility on inner subproblem warm-starts in the QILC pipeline. Callers (Intonato's `PulseTuningProblem`) need to override `bound_push` to ~1e-8 to keep warm-starts strictly feasible. Same applies to `mu_init` (for tighter initial barrier) and the warm-start variants.

## Test plan
- [ ] Verify `set_options!` forwards the new fields by running an Ipopt solve with non-default `bound_push` and confirming the printout reflects it.
- [ ] CI passes (no logic changes; only struct field additions).
- [ ] Downstream Intonato.jl `PulseTuningProblem` warm-start uses `bound_push=1e-8` and shows zero initial infeasibility on `ψ̃` boundary equalities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)