### PR TITLE
ci: shard testitem runs across 4 parallel jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - shard ${{ matrix.shard }}/4 - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
@@ -31,6 +31,16 @@ jobs:
         arch:
           - x64
           # - x86
+        shard:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+    env:
+      # Distribute @testitem blocks across `shard` parallel CI jobs.
+      # Filter logic lives in test/runtests.jl.
+      TEST_SHARD: ${{ matrix.shard }}
+      TOTAL_SHARDS: '4'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,17 @@ using TestItemRunner
 
 include("test_snippets.jl")
 
-# Run all testitem tests in package
-@run_package_tests
+# CI matrix shards the testitems across N jobs that run in parallel.
+# Locally / when unset, run everything (TOTAL_SHARDS=1).
+const TEST_SHARD    = parse(Int, get(ENV, "TEST_SHARD",    "1"))
+const TOTAL_SHARDS  = parse(Int, get(ENV, "TOTAL_SHARDS",  "1"))
+
+if TOTAL_SHARDS == 1
+    @run_package_tests
+else
+    # Stable assignment by (filename, name) hash. Same Julia version + same
+    # testitem set ⇒ same shard, so coverage is identical across runs in a
+    # single CI invocation.
+    @run_package_tests filter = ti ->
+        mod(hash((ti.filename, ti.name)), TOTAL_SHARDS) == TEST_SHARD - 1
+end


### PR DESCRIPTION
## Summary

Cuts wallclock CI time by sharding `@run_package_tests` across 4 parallel GitHub matrix jobs. Each job runs ~1/4 of the discovered testitems, selected by a stable hash of `(filename, name)`.

- `test/runtests.jl`: respects `TEST_SHARD` / `TOTAL_SHARDS` env vars. When unset (local `Pkg.test`, REPL, VS Code), behavior is unchanged — runs every testitem.
- `.github/workflows/CI.yml`: adds `shard: ['1','2','3','4']` to the matrix, sets `TOTAL_SHARDS=4`.

Expected impact: ~3x wallclock speedup once Julia precompile is amortized. Trade-off is more CI minutes total since each shard pays Julia startup separately.

## Context

This is "phase 1" of the testing parallelism plan (cf. the Julia community thread on `ReTestItems.jl` / `ParallelTestRunner.jl`):

- **Why not ReTestItems?** It requires test files to contain ONLY `@testitem` / `@testsetup` blocks. Our 80 testitems live inline in `src/**/*.jl` alongside regular code (which DirectTrajOpt's `@testsnippet DTOTestHelpers` setup uses heavily), failing ReTestItems' discovery. Migrating means relocating every testitem out of src/ — a big refactor that's worth doing eventually but not gated on this CI win.
- **Why not ParallelTestRunner?** Parallelizes at the file level. Our inline pattern collapses to one logical "file" so file-level parallelism gives us nothing.
- **What we did instead.** Sharding via `@run_package_tests filter=...` — uses TestItemRunner's existing filter hook to pick the subset for each shard. Zero new dependencies, and `test_snippets.jl` (`DTOTestHelpers`) continues to be inlined per testitem as before.

## Follow-ups (out of scope)

- [ ] Migrate `@testitem` blocks from `src/` into `test/**/*_test.jl` and adopt ReTestItems for in-process testitem-level parallelism.

## Test plan

- [ ] CI runs all 4 shards × 3 Julia versions green on this PR
- [ ] Sum of testitems across shards equals the unsharded count
- [ ] Local `Pkg.test("DirectTrajOpt")` still runs everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)