### PR TITLE
ci: gate JET correctness analysis to Julia 1.12.x only

### DIFF
--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,16 +1,18 @@
-# JET integrates tightly with the Julia compiler and is gated to v1.12 only.
+# JET integrates tightly with the Julia compiler and is gated to v1.12.x only.
 # On 1.10 / 1.11, JET 0.10 may not surface the same findings, which would
-# break `broken = true` with "Unexpected Pass". Don't relax this gate.
+# break `broken = true` with "Unexpected Pass". On 1.13+ (nightly / pre)
+# the compiler shifts faster than JET can track, so findings are noisy and
+# unactionable until JET catches up. Don't widen this gate.
 #
 # Performance analysis (type instabilities / runtime dispatch) — run manually:
 #     julia --project=. -e 'using DirectTrajOpt, JET; JET.@report_opt some_function(...)'
 
 @testitem "JET correctness analysis" tags=[:jet] begin
-    if VERSION >= v"1.12"
+    if v"1.12" <= VERSION < v"1.13"
         using JET, DirectTrajOpt
         JET.test_package(DirectTrajOpt; target_modules = (DirectTrajOpt,))
     else
-        @info "Skipping JET correctness analysis on Julia $VERSION (requires >= 1.12)"
+        @info "Skipping JET correctness analysis on Julia $VERSION (gated to 1.12.x)"
         @test true
     end
 end


### PR DESCRIPTION
## Summary
- JET 0.10+ is tightly coupled to the Julia compiler; on 1.13-pre (nightly) the compiler shifts faster than JET can track, surfacing noisy/unactionable findings.
- Tighten the gate in `test/jet.jl` from `VERSION >= v"1.12"` to `v"1.12" <= VERSION < v"1.13"`, so JET runs on 1.12.x and is muted on 1.13 nightly until JET catches up.
- Updated the rationale comment and skip-info message to reflect the new upper bound.

## Test plan
- [ ] Nightly CI no longer attempts to run JET analysis
- [x] CI on 1.12 still runs the JET testitem

Companion PRs in `Piccolo.jl` and `NamedTrajectories.jl` apply the same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)