### PR TITLE
feat(madnlp): expose intermediate_callback + fixed_variable_treatment

### DIFF
--- a/ext/MadNLPSolverExt/MadNLPSolverExt.jl
+++ b/ext/MadNLPSolverExt/MadNLPSolverExt.jl
@@ -38,7 +38,9 @@ include("utils.jl")
     @test opts isa Solvers.AbstractSolverOptions
 end
 
-@testitem "MadNLP intermediate_callback (raw MadNLP callback) fires per iter" setup=[DTOTestHelpers] begin
+@testitem "MadNLP intermediate_callback (raw MadNLP callback) fires per iter" setup=[
+    DTOTestHelpers,
+] begin
     import MadNLP
 
     mutable struct _IterCounter <: MadNLP.AbstractUserCallback
@@ -60,7 +62,9 @@ end
     @test cb.count[] > 0
 end
 
-@testitem "MadNLP intermediate_callback (AbstractIntermediateCallback) fires per iter" setup=[DTOTestHelpers] begin
+@testitem "MadNLP intermediate_callback (AbstractIntermediateCallback) fires per iter" setup=[
+    DTOTestHelpers,
+] begin
     import MadNLP
 
     mutable struct _AgnosticCounter <: DirectTrajOpt.AbstractIntermediateCallback
@@ -86,7 +90,8 @@ end
     )
     @test cb.count[] > 0
     # With RelaxBound, the primal vector matches the full NLP variable count.
-    @test cb.last_primal_len[] == length(prob.trajectory.datavec) + prob.trajectory.global_dim
+    @test cb.last_primal_len[] ==
+          length(prob.trajectory.datavec) + prob.trajectory.global_dim
 end
 
 @testitem "MadNLP intermediate_callback auto-couples RelaxBound" setup=[DTOTestHelpers] begin
@@ -105,17 +110,17 @@ end
     # Note: NOT passing fixed_variable_treatment. set_options! should auto-set it.
     solve!(
         prob;
-        options = DirectTrajOpt.MadNLPOptions(
-            max_iter = 5,
-            intermediate_callback = cb,
-        ),
+        options = DirectTrajOpt.MadNLPOptions(max_iter = 5, intermediate_callback = cb),
         verbose = false,
     )
     # If RelaxBound auto-coupled correctly, the primal includes fixed variables.
-    @test cb.last_primal_len[] == length(prob.trajectory.datavec) + prob.trajectory.global_dim
+    @test cb.last_primal_len[] ==
+          length(prob.trajectory.datavec) + prob.trajectory.global_dim
 end
 
-@testitem "MadNLP intermediate_callback early termination via return false" setup=[DTOTestHelpers] begin
+@testitem "MadNLP intermediate_callback early termination via return false" setup=[
+    DTOTestHelpers,
+] begin
     import MadNLP
 
     mutable struct _Stopper <: DirectTrajOpt.AbstractIntermediateCallback
@@ -131,10 +136,7 @@ end
     prob, _ = make_standard_prob()
     solve!(
         prob;
-        options = DirectTrajOpt.MadNLPOptions(
-            max_iter = 100,
-            intermediate_callback = cb,
-        ),
+        options = DirectTrajOpt.MadNLPOptions(max_iter = 100, intermediate_callback = cb),
         verbose = false,
     )
     # Callback stopped the solve well before max_iter=100.

--- a/ext/MadNLPSolverExt/MadNLPSolverExt.jl
+++ b/ext/MadNLPSolverExt/MadNLPSolverExt.jl
@@ -89,6 +89,71 @@ end
     @test cb.last_primal_len[] == length(prob.trajectory.datavec) + prob.trajectory.global_dim
 end
 
+@testitem "MadNLP intermediate_callback auto-couples RelaxBound" setup=[DTOTestHelpers] begin
+    import MadNLP
+
+    mutable struct _AutoCoupleProbe <: DirectTrajOpt.AbstractIntermediateCallback
+        last_primal_len::Base.RefValue{Int}
+    end
+    function (cb::_AutoCoupleProbe)(primal::AbstractVector, _)
+        cb.last_primal_len[] = length(primal)
+        return true
+    end
+
+    cb = _AutoCoupleProbe(Ref(0))
+    prob, _ = make_standard_prob()
+    # Note: NOT passing fixed_variable_treatment. set_options! should auto-set it.
+    solve!(
+        prob;
+        options = DirectTrajOpt.MadNLPOptions(
+            max_iter = 5,
+            intermediate_callback = cb,
+        ),
+        verbose = false,
+    )
+    # If RelaxBound auto-coupled correctly, the primal includes fixed variables.
+    @test cb.last_primal_len[] == length(prob.trajectory.datavec) + prob.trajectory.global_dim
+end
+
+@testitem "MadNLP intermediate_callback early termination via return false" setup=[DTOTestHelpers] begin
+    import MadNLP
+
+    mutable struct _Stopper <: DirectTrajOpt.AbstractIntermediateCallback
+        max_iters::Int
+        count::Base.RefValue{Int}
+    end
+    function (cb::_Stopper)(_, _)
+        cb.count[] += 1
+        return cb.count[] < cb.max_iters
+    end
+
+    cb = _Stopper(3, Ref(0))
+    prob, _ = make_standard_prob()
+    solve!(
+        prob;
+        options = DirectTrajOpt.MadNLPOptions(
+            max_iter = 100,
+            intermediate_callback = cb,
+        ),
+        verbose = false,
+    )
+    # Callback stopped the solve well before max_iter=100.
+    @test cb.count[] <= 5
+end
+
+@testitem "MadNLP intermediate_callback rejects invalid type" setup=[DTOTestHelpers] begin
+    prob, _ = make_standard_prob()
+    bogus_cb(args...) = true   # bare Function — neither abstract nor MadNLP subtype
+    @test_throws ArgumentError solve!(
+        prob;
+        options = DirectTrajOpt.MadNLPOptions(
+            max_iter = 5,
+            intermediate_callback = bogus_cb,
+        ),
+        verbose = false,
+    )
+end
+
 @testitem "MadNLP basic solve" setup=[DTOTestHelpers] begin
     prob, _ = make_standard_prob()
     traj_before = deepcopy(prob.trajectory.data)

--- a/ext/MadNLPSolverExt/MadNLPSolverExt.jl
+++ b/ext/MadNLPSolverExt/MadNLPSolverExt.jl
@@ -29,11 +29,35 @@ include("utils.jl")
     @test opts.max_iter == 3000
     @test opts.print_level == 3
     @test opts.hessian_approximation == "exact"
+    @test opts.intermediate_callback === nothing
+    @test opts.fixed_variable_treatment === nothing
 
     opts2 = DirectTrajOpt.MadNLPOptions(max_iter = 100, tol = 1e-6)
     @test opts2.max_iter == 100
     @test opts2.tol == 1e-6
     @test opts isa Solvers.AbstractSolverOptions
+end
+
+@testitem "MadNLP intermediate_callback fires per iter" setup=[DTOTestHelpers] begin
+    import MadNLP
+
+    mutable struct _IterCounter <: MadNLP.AbstractUserCallback
+        count::Base.RefValue{Int}
+    end
+    (cb::_IterCounter)(::MadNLP.AbstractMadNLPSolver, _) = (cb.count[] += 1; true)
+
+    cb = _IterCounter(Ref(0))
+    prob, _ = make_standard_prob()
+    solve!(
+        prob;
+        options = DirectTrajOpt.MadNLPOptions(
+            max_iter = 5,
+            intermediate_callback = cb,
+            fixed_variable_treatment = MadNLP.RelaxBound,
+        ),
+        verbose = false,
+    )
+    @test cb.count[] > 0
 end
 
 @testitem "MadNLP basic solve" setup=[DTOTestHelpers] begin

--- a/ext/MadNLPSolverExt/MadNLPSolverExt.jl
+++ b/ext/MadNLPSolverExt/MadNLPSolverExt.jl
@@ -118,6 +118,37 @@ end
           length(prob.trajectory.datavec) + prob.trajectory.global_dim
 end
 
+@testitem "MadNLP auto-couple respects MadNLP's conditional default" setup=[DTOTestHelpers] begin
+    import MadNLP
+    using Logging
+
+    mutable struct _PassthroughProbe <: DirectTrajOpt.AbstractIntermediateCallback
+        len::Base.RefValue{Int}
+    end
+    (cb::_PassthroughProbe)(primal, _) = (cb.len[] = length(primal); true)
+
+    cb = _PassthroughProbe(Ref(0))
+    prob, _ = make_standard_prob()
+    # With `kkt_system = SparseCondensedKKTSystem`, MadNLP's own conditional
+    # default for `fixed_variable_treatment` is already `RelaxBound`, so the
+    # auto-couple should not fire. Capture @info logs and assert ours is absent.
+    buf = IOBuffer()
+    with_logger(SimpleLogger(buf, Logging.Info)) do
+        solve!(
+            prob;
+            options = DirectTrajOpt.MadNLPOptions(
+                max_iter = 5,
+                intermediate_callback = cb,
+                kkt_system = MadNLP.SparseCondensedKKTSystem,
+            ),
+            verbose = false,
+        )
+    end
+    @test !occursin("Setting fixed_variable_treatment", String(take!(buf)))
+    # MadNLP's untouched conditional default still yields the full primal.
+    @test cb.len[] == length(prob.trajectory.datavec) + prob.trajectory.global_dim
+end
+
 @testitem "MadNLP intermediate_callback early termination via return false" setup=[
     DTOTestHelpers,
 ] begin

--- a/ext/MadNLPSolverExt/MadNLPSolverExt.jl
+++ b/ext/MadNLPSolverExt/MadNLPSolverExt.jl
@@ -120,7 +120,6 @@ end
 
 @testitem "MadNLP auto-couple respects MadNLP's conditional default" setup=[DTOTestHelpers] begin
     import MadNLP
-    using Logging
 
     mutable struct _PassthroughProbe <: DirectTrajOpt.AbstractIntermediateCallback
         len::Base.RefValue{Int}
@@ -131,9 +130,8 @@ end
     prob, _ = make_standard_prob()
     # With `kkt_system = SparseCondensedKKTSystem`, MadNLP's own conditional
     # default for `fixed_variable_treatment` is already `RelaxBound`, so the
-    # auto-couple should not fire. Capture @info logs and assert ours is absent.
-    buf = IOBuffer()
-    with_logger(SimpleLogger(buf, Logging.Info)) do
+    # auto-couple should not fire. Capture logs and assert our @info is absent.
+    logs, _ = Test.collect_test_logs() do
         solve!(
             prob;
             options = DirectTrajOpt.MadNLPOptions(
@@ -144,7 +142,7 @@ end
             verbose = false,
         )
     end
-    @test !occursin("Setting fixed_variable_treatment", String(take!(buf)))
+    @test !any(l -> occursin("Setting fixed_variable_treatment", l.message), logs)
     # MadNLP's untouched conditional default still yields the full primal.
     @test cb.len[] == length(prob.trajectory.datavec) + prob.trajectory.global_dim
 end

--- a/ext/MadNLPSolverExt/MadNLPSolverExt.jl
+++ b/ext/MadNLPSolverExt/MadNLPSolverExt.jl
@@ -38,7 +38,7 @@ include("utils.jl")
     @test opts isa Solvers.AbstractSolverOptions
 end
 
-@testitem "MadNLP intermediate_callback fires per iter" setup=[DTOTestHelpers] begin
+@testitem "MadNLP intermediate_callback (raw MadNLP callback) fires per iter" setup=[DTOTestHelpers] begin
     import MadNLP
 
     mutable struct _IterCounter <: MadNLP.AbstractUserCallback
@@ -58,6 +58,35 @@ end
         verbose = false,
     )
     @test cb.count[] > 0
+end
+
+@testitem "MadNLP intermediate_callback (AbstractIntermediateCallback) fires per iter" setup=[DTOTestHelpers] begin
+    import MadNLP
+
+    mutable struct _AgnosticCounter <: DirectTrajOpt.AbstractIntermediateCallback
+        count::Base.RefValue{Int}
+        last_primal_len::Base.RefValue{Int}
+    end
+    function (cb::_AgnosticCounter)(primal::AbstractVector, iter::Integer)
+        cb.count[] += 1
+        cb.last_primal_len[] = length(primal)
+        return true
+    end
+
+    cb = _AgnosticCounter(Ref(0), Ref(0))
+    prob, _ = make_standard_prob()
+    solve!(
+        prob;
+        options = DirectTrajOpt.MadNLPOptions(
+            max_iter = 5,
+            intermediate_callback = cb,
+            fixed_variable_treatment = MadNLP.RelaxBound,
+        ),
+        verbose = false,
+    )
+    @test cb.count[] > 0
+    # With RelaxBound, the primal vector matches the full NLP variable count.
+    @test cb.last_primal_len[] == length(prob.trajectory.datavec) + prob.trajectory.global_dim
 end
 
 @testitem "MadNLP basic solve" setup=[DTOTestHelpers] begin

--- a/ext/MadNLPSolverExt/solver.jl
+++ b/ext/MadNLPSolverExt/solver.jl
@@ -232,13 +232,21 @@ function DirectTrajOpt.set_options!(optimizer::AbstractOptimizer, options::MadNL
     ignored_options = [:eval_hessian]
 
     # Auto-couple: an AbstractIntermediateCallback needs the full primal vector,
-    # which requires fixed_variable_treatment = RelaxBound. If the user installed
-    # an agnostic callback without setting fixed_variable_treatment, apply it for
-    # them. Raw MadNLP callbacks are presumed to manage this themselves.
+    # which requires fixed_variable_treatment = RelaxBound. We only override when
+    # MadNLP's own conditional default (`kkt_system <: SparseCondensedKKTSystem ?
+    # RelaxBound : MakeParameter`) would otherwise pick `MakeParameter` and break
+    # the callback. When the user has selected a kkt_system whose default is
+    # already `RelaxBound`, MadNLP's if-one-liner gets to do its job untouched.
+    # Raw MadNLP callbacks are presumed to manage this themselves.
     if options.intermediate_callback isa DirectTrajOpt.AbstractIntermediateCallback &&
        options.fixed_variable_treatment === nothing
-        @info "Setting fixed_variable_treatment = MadNLP.RelaxBound for AbstractIntermediateCallback (required for full-primal access)"
-        optimizer.options[:fixed_variable_treatment] = MadNLP.RelaxBound
+        madnlp_default_is_relax_bound =
+            options.kkt_system isa Type &&
+            options.kkt_system <: MadNLP.SparseCondensedKKTSystem
+        if !madnlp_default_is_relax_bound
+            @info "Setting fixed_variable_treatment = MadNLP.RelaxBound for AbstractIntermediateCallback (MadNLP's kkt_system default would otherwise eliminate fixed vars from solver.x)"
+            optimizer.options[:fixed_variable_treatment] = MadNLP.RelaxBound
+        end
     end
 
     for name in fieldnames(typeof(options))

--- a/ext/MadNLPSolverExt/solver.jl
+++ b/ext/MadNLPSolverExt/solver.jl
@@ -200,6 +200,22 @@ end
 # ----------------------------------------------------------------------------
 
 
+"""
+    _MadNLPCallbackAdapter(inner)
+
+Wrap a `DirectTrajOpt.AbstractIntermediateCallback` so MadNLP can call it
+with its native `(solver, mode)` signature. Translates `solver.x` (with
+slacks) into just the NLP primal via `MadNLP.variable`, and forwards
+`solver.cnt.k` as the iteration index.
+"""
+struct _MadNLPCallbackAdapter <: MadNLP.AbstractUserCallback
+    inner::DirectTrajOpt.AbstractIntermediateCallback
+end
+
+function (a::_MadNLPCallbackAdapter)(solver::MadNLP.AbstractMadNLPSolver, _mode)
+    return a.inner(MadNLP.variable(solver.x), solver.cnt.k)
+end
+
 function DirectTrajOpt.set_options!(optimizer::AbstractOptimizer, options::MadNLPOptions)
     ignored_options = [:eval_hessian]
 
@@ -221,6 +237,11 @@ function DirectTrajOpt.set_options!(optimizer::AbstractOptimizer, options::MadNL
             hessian_approximation =
                 ((value == "compact_lbfgs") ? MadNLP.CompactLBFGS : hessian_approximation)
             optimizer.options[name] = hessian_approximation
+        elseif name == :intermediate_callback &&
+               value isa DirectTrajOpt.AbstractIntermediateCallback
+            # Wrap solver-agnostic callbacks in the MadNLP-shaped adapter.
+            # Raw `MadNLP.AbstractUserCallback` subtypes fall through unwrapped.
+            optimizer.options[name] = _MadNLPCallbackAdapter(value)
         else
             optimizer.options[name] = value
         end

--- a/ext/MadNLPSolverExt/solver.jl
+++ b/ext/MadNLPSolverExt/solver.jl
@@ -204,20 +204,42 @@ end
     _MadNLPCallbackAdapter(inner)
 
 Wrap a `DirectTrajOpt.AbstractIntermediateCallback` so MadNLP can call it
-with its native `(solver, mode)` signature. Translates `solver.x` (with
-slacks) into just the NLP primal via `MadNLP.variable`, and forwards
-`solver.cnt.k` as the iteration index.
+with its native `(solver, mode)` signature.
+
+The adapter:
+- **Filters mode to `UserCallbackRegular`.** MadNLP also invokes user
+  callbacks during feasibility restoration and robust mode; those phases
+  surface intermediate IPM state that's typically not meaningful to a
+  trajectory-level callback, so they're silently skipped (return `true`).
+  This makes `solver.cnt.k` monotonic from the callback's point of view.
+- **Translates `solver.x` → `MadNLP.variable(solver.x)`** to strip the
+  slack tail and hand back just the NLP primal.
+- **Forwards `solver.cnt.k`** as the iteration index.
 """
 struct _MadNLPCallbackAdapter <: MadNLP.AbstractUserCallback
     inner::DirectTrajOpt.AbstractIntermediateCallback
 end
 
-function (a::_MadNLPCallbackAdapter)(solver::MadNLP.AbstractMadNLPSolver, _mode)
+function (a::_MadNLPCallbackAdapter)(
+    solver::MadNLP.AbstractMadNLPSolver,
+    mode::MadNLP.AbstractUserCallbackStatus,
+)
+    mode isa MadNLP.UserCallbackRegular || return true
     return a.inner(MadNLP.variable(solver.x), solver.cnt.k)
 end
 
 function DirectTrajOpt.set_options!(optimizer::AbstractOptimizer, options::MadNLPOptions)
     ignored_options = [:eval_hessian]
+
+    # Auto-couple: an AbstractIntermediateCallback needs the full primal vector,
+    # which requires fixed_variable_treatment = RelaxBound. If the user installed
+    # an agnostic callback without setting fixed_variable_treatment, apply it for
+    # them. Raw MadNLP callbacks are presumed to manage this themselves.
+    if options.intermediate_callback isa DirectTrajOpt.AbstractIntermediateCallback &&
+       options.fixed_variable_treatment === nothing
+        @info "Setting fixed_variable_treatment = MadNLP.RelaxBound for AbstractIntermediateCallback (required for full-primal access)"
+        optimizer.options[:fixed_variable_treatment] = MadNLP.RelaxBound
+    end
 
     for name in fieldnames(typeof(options))
         value = getfield(options, name)
@@ -237,11 +259,22 @@ function DirectTrajOpt.set_options!(optimizer::AbstractOptimizer, options::MadNL
             hessian_approximation =
                 ((value == "compact_lbfgs") ? MadNLP.CompactLBFGS : hessian_approximation)
             optimizer.options[name] = hessian_approximation
-        elseif name == :intermediate_callback &&
-               value isa DirectTrajOpt.AbstractIntermediateCallback
-            # Wrap solver-agnostic callbacks in the MadNLP-shaped adapter.
-            # Raw `MadNLP.AbstractUserCallback` subtypes fall through unwrapped.
-            optimizer.options[name] = _MadNLPCallbackAdapter(value)
+        elseif name == :intermediate_callback
+            if value isa DirectTrajOpt.AbstractIntermediateCallback
+                # Wrap solver-agnostic callbacks in the MadNLP-shaped adapter.
+                optimizer.options[name] = _MadNLPCallbackAdapter(value)
+            elseif value isa MadNLP.AbstractUserCallback
+                # Raw MadNLP callbacks pass through unwrapped.
+                optimizer.options[name] = value
+            else
+                throw(
+                    ArgumentError(
+                        "intermediate_callback must be a subtype of " *
+                        "`DirectTrajOpt.AbstractIntermediateCallback` or " *
+                        "`MadNLP.AbstractUserCallback`, got $(typeof(value))",
+                    ),
+                )
+            end
         else
             optimizer.options[name] = value
         end

--- a/src/solvers/_solvers.jl
+++ b/src/solvers/_solvers.jl
@@ -2,6 +2,7 @@ module Solvers
 
 export AbstractOptimizer
 export AbstractSolverOptions, DefaultSolverOptions, _DefaultSolverOptions
+export AbstractIntermediateCallback
 export _solve
 export _solve_with_kwargs
 export solve!
@@ -16,6 +17,24 @@ using TestItemRunner
 
 const AbstractOptimizer = MOI.AbstractOptimizer
 abstract type AbstractSolverOptions end
+
+"""
+    AbstractIntermediateCallback
+
+Solver-agnostic per-iteration callback for trajectory optimization.
+
+Subtypes implement a callable with signature
+
+    (cb::SubType)(primal::AbstractVector, iter::Integer) -> Bool
+
+where `primal` is the current full NLP primal vector and `iter` is the
+iteration index. Return `true` to continue solving, `false` to stop early.
+
+Each solver extension wraps an `AbstractIntermediateCallback` instance in a
+solver-specific adapter at solve time, so the same callback object works
+with every backend (MadNLP, Ipopt, …).
+"""
+abstract type AbstractIntermediateCallback end
 
 struct DefaultSolverOptions <: AbstractSolverOptions end
 const _DefaultSolverOptions::Ref{Type{<:AbstractSolverOptions}} =

--- a/src/solvers/_solvers.jl
+++ b/src/solvers/_solvers.jl
@@ -28,11 +28,33 @@ Subtypes implement a callable with signature
     (cb::SubType)(primal::AbstractVector, iter::Integer) -> Bool
 
 where `primal` is the current full NLP primal vector and `iter` is the
-iteration index. Return `true` to continue solving, `false` to stop early.
+iteration index from the solver's main optimization loop. Return `true` to
+continue solving, `false` to stop early (the solver will report a
+user-requested termination).
 
 Each solver extension wraps an `AbstractIntermediateCallback` instance in a
 solver-specific adapter at solve time, so the same callback object works
 with every backend (MadNLP, Ipopt, …).
+
+# Contract
+
+- **`primal` may alias the solver's internal vector.** Copy it (e.g.
+  `collect(primal)`) if you need to retain the data past the callback
+  invocation — its contents may shift on the next iteration.
+- **`iter` is monotonic.** The callback is invoked only from the solver's
+  main IPM loop; auxiliary phases (e.g. MadNLP's feasibility restoration
+  or robust modes) do not fire it.
+
+# Required MadNLP setup
+
+When using MadNLP, the callback must receive the **full** primal vector
+to reconstruct trajectories correctly. MadNLP's default
+`fixed_variable_treatment = MakeParameter` eliminates variables with
+`lb == ub` from the working primal, so any subtype that maps `primal`
+back onto a `NamedTrajectory` needs `fixed_variable_treatment =
+MadNLP.RelaxBound`. When an `AbstractIntermediateCallback` is installed
+via `MadNLPOptions.intermediate_callback`, DTO sets this automatically
+(with an `@info` log) unless the user has provided a value.
 """
 abstract type AbstractIntermediateCallback end
 

--- a/src/solvers/madnlp_solver/options.jl
+++ b/src/solvers/madnlp_solver/options.jl
@@ -28,14 +28,18 @@ export MadNLPOptions
     intermediate_callback::Any = nothing
 
     # Controls how MadNLP handles variables with `lb == ub`. Mirrors MadNLP's
-    # own `fixed_variable_treatment::Type` field — must be a `Type` subtype of
-    # `MadNLP.AbstractFixedVariableTreatment` (e.g. `MadNLP.MakeParameter` or
-    # `MadNLP.RelaxBound`). Default (`nothing`) defers to MadNLP's kkt_system-
-    # aware default: `RelaxBound` for `SparseCondensedKKTSystem`, otherwise
-    # `MakeParameter`. Pass `MadNLP.RelaxBound` explicitly if a callback needs
-    # the full primal vector (auto-coupled by `set_options!` when an
-    # `AbstractIntermediateCallback` is installed and this field is left at
-    # the default).
+    # own `fixed_variable_treatment::Type` field — must be a `Type` (typically
+    # `MadNLP.MakeParameter` or `MadNLP.RelaxBound`). Default (`nothing`) defers
+    # to MadNLP's kkt_system-aware conditional default:
+    #
+    #     kkt_system <: SparseCondensedKKTSystem ? RelaxBound : MakeParameter
+    #
+    # When an `AbstractIntermediateCallback` is installed and this field is
+    # left at `nothing`, `set_options!` only overrides to `RelaxBound` if
+    # MadNLP's conditional default would otherwise be `MakeParameter` (which
+    # eliminates fixed boundary vars from `solver.x` and breaks trajectory
+    # reconstruction). The conditional default's `RelaxBound` branch is left
+    # untouched.
     fixed_variable_treatment::Union{Type,Nothing} = nothing
 
     # # Only supported by DirectTrajOpt._solve, as an optional kwarg override of `hessian_approximation`;

--- a/src/solvers/madnlp_solver/options.jl
+++ b/src/solvers/madnlp_solver/options.jl
@@ -27,11 +27,16 @@ export MadNLPOptions
     # Return `false` to stop the solver (yields `USER_REQUESTED_STOP`).
     intermediate_callback::Any = nothing
 
-    # Controls how MadNLP handles variables with `lb == ub`. Default (`nothing`)
-    # uses MadNLP's `MakeParameter`, which eliminates fixed vars from `solver.x`.
-    # Pass `MadNLP.RelaxBound` if a callback needs the full primal vector (e.g.
-    # to reconstruct a `NamedTrajectory` from `MadNLP.variable(solver.x)`).
-    fixed_variable_treatment::Any = nothing
+    # Controls how MadNLP handles variables with `lb == ub`. Mirrors MadNLP's
+    # own `fixed_variable_treatment::Type` field — must be a `Type` subtype of
+    # `MadNLP.AbstractFixedVariableTreatment` (e.g. `MadNLP.MakeParameter` or
+    # `MadNLP.RelaxBound`). Default (`nothing`) defers to MadNLP's kkt_system-
+    # aware default: `RelaxBound` for `SparseCondensedKKTSystem`, otherwise
+    # `MakeParameter`. Pass `MadNLP.RelaxBound` explicitly if a callback needs
+    # the full primal vector (auto-coupled by `set_options!` when an
+    # `AbstractIntermediateCallback` is installed and this field is left at
+    # the default).
+    fixed_variable_treatment::Union{Type,Nothing} = nothing
 
     # # Only supported by DirectTrajOpt._solve, as an optional kwarg override of `hessian_approximation`;
     # #   `hessian_approximation = eval_hessian ? "exact" : "compact_lbfgs"`

--- a/src/solvers/madnlp_solver/options.jl
+++ b/src/solvers/madnlp_solver/options.jl
@@ -14,6 +14,17 @@ export MadNLPOptions
     kkt_system::Any = nothing  # e.g. MadNLP.SparseUnreducedKKTSystem
     cudss_ordering::Any = nothing  # e.g. MadNLPGPU.AMD_ORDERING
 
+    # Per-iteration user callback. Must be a subtype of `MadNLP.AbstractUserCallback`
+    # with call signature `(cb)(solver::MadNLP.AbstractMadNLPSolver, mode) -> Bool`.
+    # Return `false` to stop the solver (yields `USER_REQUESTED_STOP`).
+    intermediate_callback::Any = nothing
+
+    # Controls how MadNLP handles variables with `lb == ub`. Default (`nothing`)
+    # uses MadNLP's `MakeParameter`, which eliminates fixed vars from `solver.x`.
+    # Pass `MadNLP.RelaxBound` if a callback needs the full primal vector (e.g.
+    # to reconstruct a `NamedTrajectory` from `MadNLP.variable(solver.x)`).
+    fixed_variable_treatment::Any = nothing
+
     # # Only supported by DirectTrajOpt._solve, as an optional kwarg override of `hessian_approximation`;
     # #   `hessian_approximation = eval_hessian ? "exact" : "compact_lbfgs"`
     # eval_hessian::Bool = true

--- a/src/solvers/madnlp_solver/options.jl
+++ b/src/solvers/madnlp_solver/options.jl
@@ -14,8 +14,16 @@ export MadNLPOptions
     kkt_system::Any = nothing  # e.g. MadNLP.SparseUnreducedKKTSystem
     cudss_ordering::Any = nothing  # e.g. MadNLPGPU.AMD_ORDERING
 
-    # Per-iteration user callback. Must be a subtype of `MadNLP.AbstractUserCallback`
-    # with call signature `(cb)(solver::MadNLP.AbstractMadNLPSolver, mode) -> Bool`.
+    # Per-iteration user callback. Two accepted forms:
+    #
+    #   1. A subtype of `DirectTrajOpt.AbstractIntermediateCallback` (solver-agnostic).
+    #      Signature: `(cb)(primal::AbstractVector, iter::Integer) -> Bool`.
+    #      The MadNLP extension wraps it in an internal adapter at solve time.
+    #
+    #   2. A raw `MadNLP.AbstractUserCallback` subtype with native MadNLP signature
+    #      `(cb)(solver::MadNLP.AbstractMadNLPSolver, mode) -> Bool` — passed through
+    #      unwrapped for users who want full access to the IPM state.
+    #
     # Return `false` to stop the solver (yields `USER_REQUESTED_STOP`).
     intermediate_callback::Any = nothing
 


### PR DESCRIPTION
## Summary

Adds the plumbing needed to install solver-agnostic per-iteration callbacks during a `solve!`, with MadNLP wired up. Two layers:

### Layer 1 — MadNLP-specific pass-throughs (`MadNLPOptions`)
- `intermediate_callback::Any = nothing` — install any per-iter callback. Accepts either a raw `MadNLP.AbstractUserCallback` (passed through unwrapped) or a `DirectTrajOpt.AbstractIntermediateCallback` (wrapped in an internal adapter). Return `false` to terminate the solve (yields `USER_REQUESTED_STOP`).
- `fixed_variable_treatment::Any = nothing` — override MadNLP's handling of variables with `lb == ub`. Default behaviour unchanged; pass `MadNLP.RelaxBound` when a callback needs the full primal vector.

### Layer 2 — solver-agnostic abstraction (`DirectTrajOpt.AbstractIntermediateCallback`)

A new abstract type lives in the `Solvers` submodule. Subtypes implement the uniform signature

```julia
(cb)(primal::AbstractVector, iter::Integer) -> Bool
```

Each solver extension owns the adapter that translates this into the native callback shape. MadNLP's adapter (`_MadNLPCallbackAdapter <: MadNLP.AbstractUserCallback`) wraps `(solver, mode) → (variable(solver.x), solver.cnt.k)`. Future Ipopt wiring will add a parallel adapter inside `IpoptSolverExt`.

This means downstream packages (Piccolo, etc.) can ship per-iter callbacks — live pulse plotting, custom stopping criteria, analysis hooks — by subtyping `AbstractIntermediateCallback` once, without taking a weak dep on every solver backend.

## Why both fields

A callback that wants to reconstruct a `NamedTrajectory` from the primal vector (the use case that motivated this — live pulse plotting during optimization) cannot work with MadNLP's default `MakeParameter`, which eliminates fixed boundary variables from the IPM's working primal vector. The two fields ship together so that pattern works out-of-the-box.

## Behaviour change

None for existing users. Both fields default to `nothing` and are skipped by the existing generic `set_options!` loop.

## Test plan

- [x] `MadNLPOptions construction` testitem extended to assert both defaults are `nothing`
- [x] `MadNLP intermediate_callback (raw MadNLP callback) fires per iter` — verifies a `MadNLP.AbstractUserCallback` subtype runs on every IPM iteration
- [x] `MadNLP intermediate_callback (AbstractIntermediateCallback) fires per iter` — verifies the solver-agnostic adapter path: callback is wrapped, receives full primal vector matching `length(traj.datavec) + traj.global_dim` (with `RelaxBound`)
- [x] End-to-end smoke test (out of repo): 200-iter `SmoothPulseProblem` X-gate solve with a `LivePulsePlotCallback <: AbstractIntermediateCallback` saving a PNG per iter via Piccolo's `plot_pulse`. Wiring is solid; the rendered frames track the converging pulse correctly.

## Follow-ups

- Parallel adapter in `IpoptSolverExt` so the same `AbstractIntermediateCallback` instance works with both solvers.
- Piccolo PR exposing `LivePulsePlotCallback <: AbstractIntermediateCallback` from `PiccoloMakieExt` (no new triple-trigger extension needed thanks to this abstraction).