### PR TITLE
bump: v0.9.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DirectTrajOpt"
 uuid = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Patch bump for the release containing #98 (callback hooks + `AbstractIntermediateCallback` abstraction) and #97 (allocation fixes in NLP assembly).

Purely additive; no breaking changes. Once merged, `@JuliaRegistrator register` goes on the resulting merge commit.