### PR TITLE
ci(benchmarks): publish dashboards on v* tags (fix never-publishing gate)

### DIFF
--- a/.github/workflows/alloc-profile.yml
+++ b/.github/workflows/alloc-profile.yml
@@ -64,9 +64,10 @@ jobs:
           path: benchmark/results/allocs/
           retention-days: 90
 
-      # Publish to /bench-alloc on gh-pages — per-commit series for each solver's
-      # total sampled allocations, with 120% regression alerts. save-data-file /
-      # auto-push gated to main so PR runs render a comparison only.
+      # Publish to /bench-alloc on gh-pages — per-release series for each solver's
+      # total sampled allocations, with 120% regression alerts. This workflow only
+      # runs on v* tags and PRs; save-data-file / auto-push gated to tag refs so
+      # PR runs render a comparison only.
       - name: Publish alloc profile to gh-pages
         if: success() && hashFiles('benchmark/results/allocs/bench.json') != ''
         uses: benchmark-action/github-action-benchmark@v1
@@ -80,5 +81,5 @@ jobs:
           alert-threshold: '120%'
           comment-on-alert: true
           fail-on-alert: false
-          save-data-file: ${{ github.ref == 'refs/heads/main' }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          save-data-file: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          auto-push: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/benchmark-convergence.yml
+++ b/.github/workflows/benchmark-convergence.yml
@@ -60,9 +60,10 @@ jobs:
           retention-days: 90
 
       # Publish to /bench-convergence on gh-pages (separate dashboard from the
-      # timing suite's /bench). Per-commit time series for wall/alloc/iters and
-      # achieved infidelity, with 120% regression alerts. save-data-file /
-      # auto-push gated to main so PR runs render a comparison only.
+      # timing suite's /bench). Per-release time series for wall/alloc/iters and
+      # achieved infidelity, with 120% regression alerts. This workflow only runs
+      # on v* tags and PRs; save-data-file / auto-push gated to tag refs so PR
+      # runs render a comparison only.
       - name: Publish convergence benchmark to gh-pages
         if: success() && hashFiles('benchmark/convergence/results/bench.json') != ''
         uses: benchmark-action/github-action-benchmark@v1
@@ -76,5 +77,5 @@ jobs:
           alert-threshold: '120%'
           comment-on-alert: true
           fail-on-alert: false
-          save-data-file: ${{ github.ref == 'refs/heads/main' }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          save-data-file: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          auto-push: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,10 +67,11 @@ jobs:
           path: benchmark/results/
           retention-days: 90
 
-      # Publish to /bench on gh-pages (per-commit time-series chart + regression
-      # alerts), mirroring CuQuantum.jl. save-data-file / auto-push are gated to
-      # main so PR / branch runs render a comparison comment without polluting
-      # the published series.
+      # Publish to /bench on gh-pages (per-release time-series chart + regression
+      # alerts), mirroring CuQuantum.jl. This workflow only runs on v* tags and
+      # PRs (see `on:`); save-data-file / auto-push are gated to tag refs so PR
+      # runs render a comparison comment without polluting the published series.
+      # (The series is therefore indexed by release tag, not per-commit.)
       - name: Publish benchmark to gh-pages
         if: success() && hashFiles('benchmark/results/bench.json') != ''
         uses: benchmark-action/github-action-benchmark@v1
@@ -84,5 +85,5 @@ jobs:
           alert-threshold: '120%'
           comment-on-alert: true
           fail-on-alert: false
-          save-data-file: ${{ github.ref == 'refs/heads/main' }}
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          save-data-file: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          auto-push: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Fixes the mutually-exclusive trigger/gate that left /bench, /bench-alloc, /bench-convergence empty. Trigger is v* tags + PRs; gate was refs/heads/main → never true. Now gated on `startsWith(github.ref,'refs/tags/v')` (per-release publishing, the chosen policy). Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)