### PR TITLE
chore: autoformat convergence.jl

### DIFF
--- a/benchmark/convergence/convergence.jl
+++ b/benchmark/convergence/convergence.jl
@@ -94,11 +94,8 @@ end
     end
     iter_counter = _MadNLPIterCounter(0)
 
-    madnlp_opts = MadNLPOptions(
-        max_iter = 500,
-        print_level = 6,
-        intermediate_callback = iter_counter,
-    )
+    madnlp_opts =
+        MadNLPOptions(max_iter = 500, print_level = 6, intermediate_callback = iter_counter)
 
     result = benchmark_solve!(
         prob,


### PR DESCRIPTION
Formatter-only: JuliaFormatter wants MadNLPOptions(...) on one line. Fixes the red Formatter check on main from #109. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)