### PR TITLE
feat: GlobalLinearConstraint — linear relations/bounds on a global block

### DIFF
--- a/src/constraints/_constraints.jl
+++ b/src/constraints/_constraints.jl
@@ -248,6 +248,7 @@ include("linear/total_constraint.jl")
 include("linear/symmetry_constraint.jl")
 include("linear/time_consistency_constraint.jl")
 include("linear/l1_slack_constraint.jl")
+include("linear/global_linear_constraint.jl")
 
 # Nonlinear constraints
 include("nonlinear/knot_point_constraint.jl")

--- a/src/constraints/linear/global_linear_constraint.jl
+++ b/src/constraints/linear/global_linear_constraint.jl
@@ -44,7 +44,9 @@ function GlobalLinearConstraint(
     ub::AbstractVector;
     label::String = "global linear constraint on :$name",
 )
-    As = sparse(Matrix{Float64}(A))
+    # Preserve sparsity (don't densify a banded slew-bound A): convert straight
+    # to CSC. SparseArrays.sparse on a dense Matrix would be O(rows×cols).
+    As = convert(SparseMatrixCSC{Float64,Int}, A)
     size(As, 1) == length(lb) == length(ub) || throw(
         ArgumentError(
             "row count mismatch: A has $(size(As,1)) rows, lb has $(length(lb)), ub has $(length(ub))",
@@ -90,7 +92,9 @@ end
 
     gdim = length(traj.global_components[:g])
     # one row: g[1] - g[2] = 0
-    A = spzeros(1, gdim); A[1, 1] = 1.0; A[1, 2] = -1.0
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = -1.0
     con = GlobalLinearConstraint(:g, A, [0.0])
 
     prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
@@ -116,7 +120,9 @@ end
 
     gdim = length(traj.global_components[:g])
     # -0.1 ≤ g[1] - g[2] ≤ 0.1
-    A = spzeros(1, gdim); A[1, 1] = 1.0; A[1, 2] = -1.0
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = -1.0
     con = GlobalLinearConstraint(:g, A, [-0.1], [0.1])
 
     prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
@@ -125,4 +131,120 @@ end
     g = prob.trajectory.global_data[traj.global_components[:g]]
     @test g[1] - g[2] <= 0.1 + 1e-7
     @test g[1] - g[2] >= -0.1 - 1e-7
+end
+
+@testitem "GlobalLinearConstraint - infeasible all-zero row is surfaced" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # All-zero row reduces to 1 ≤ 0·g ≤ 2, i.e. 1 ≤ 0 ≤ 2 — infeasible.
+    A = spzeros(1, gdim)
+    con = GlobalLinearConstraint(:g, A, [1.0], [2.0])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    @test_throws ErrorException solve!(prob; max_iter = 1)
+end
+
+@testitem "GlobalLinearConstraint - multi-row banded slew bound" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # Banded first-difference operator: |g[i+1] - g[i]| ≤ vmax for all i.
+    nrows = gdim - 1
+    A = spzeros(nrows, gdim)
+    for i = 1:nrows
+        A[i, i] = -1.0
+        A[i, i+1] = 1.0
+    end
+    vmax = 0.5
+    con = GlobalLinearConstraint(:g, A, fill(-vmax, nrows), fill(vmax, nrows))
+    # The conversion must keep A sparse (not densify it).
+    @test con.A isa SparseMatrixCSC{Float64,Int}
+    @test nnz(con.A) == 2nrows
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test all(abs.(diff(g)) .<= vmax + 1e-7)
+end
+
+@testitem "GlobalLinearConstraint - one-sided (Inf) bound" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # Only a lower bound: g[1] - g[2] ≥ 0.2, upper side is +Inf (must be skipped,
+    # emitting a lone GreaterThan and no LessThan).
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = -1.0
+    con = GlobalLinearConstraint(:g, A, [0.2], [Inf])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test g[1] - g[2] >= 0.2 - 1e-7
+end
+
+@testitem "GlobalLinearConstraint - equality overload A·g = b" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # Two-arg equality form: g[1] + g[2] = 1.0.
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = 1.0
+    con = GlobalLinearConstraint(:g, A, [1.0])
+    @test con.lb == con.ub == [1.0]
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test abs(g[1] + g[2] - 1.0) < 1e-7
 end

--- a/src/constraints/linear/global_linear_constraint.jl
+++ b/src/constraints/linear/global_linear_constraint.jl
@@ -1,0 +1,128 @@
+export GlobalLinearConstraint
+
+using SparseArrays
+
+"""
+    struct GlobalLinearConstraint <: AbstractLinearConstraint
+
+A general linear constraint on a global variable block: `lb ≤ A·g ≤ ub`, where
+`g` is the global block named `name` (length = number of columns of `A`). Each
+row of `A` becomes one affine row over the global variables; rows with
+`lb[r] == ub[r]` are emitted as equalities (`MOI.EqualTo`), otherwise as the
+finite-sided bounds (`GreaterThan`/`LessThan`, skipping `±Inf`).
+
+This is the primitive for relations and bounds on *subcomponents* of a global
+block — which the per-variable `BoundsConstraint`/`GlobalEqualityConstraint`
+cannot express (they pin the whole block to values, not linear combinations of
+its slots). Typical uses: pin a B-spline endpoint *derivative*
+(`c₁ − c₀ = 0`, an equality relation) or bound a B-spline slew
+(`|c_{i+1} − c_i| ≤ vₘₐₓ`, a two-sided inequality).
+
+# Fields
+- `name::Symbol`: global block to constrain (a key of `traj.global_components`)
+- `A::SparseMatrixCSC{Float64,Int}`: `(n_rows × global_dim)` coefficient matrix
+- `lb::Vector{Float64}`, `ub::Vector{Float64}`: per-row bounds (length `n_rows`)
+- `label::String`
+"""
+struct GlobalLinearConstraint <: AbstractLinearConstraint
+    name::Symbol
+    A::SparseMatrixCSC{Float64,Int}
+    lb::Vector{Float64}
+    ub::Vector{Float64}
+    label::String
+end
+
+"""
+    GlobalLinearConstraint(name, A, lb, ub; label=...)
+
+Inequality form `lb ≤ A·g ≤ ub`. `A` may be any `AbstractMatrix` (stored sparse).
+"""
+function GlobalLinearConstraint(
+    name::Symbol,
+    A::AbstractMatrix,
+    lb::AbstractVector,
+    ub::AbstractVector;
+    label::String = "global linear constraint on :$name",
+)
+    As = sparse(Matrix{Float64}(A))
+    size(As, 1) == length(lb) == length(ub) || throw(
+        ArgumentError(
+            "row count mismatch: A has $(size(As,1)) rows, lb has $(length(lb)), ub has $(length(ub))",
+        ),
+    )
+    all(lb .<= ub) || throw(ArgumentError("lb must be elementwise ≤ ub"))
+    return GlobalLinearConstraint(name, As, Vector{Float64}(lb), Vector{Float64}(ub), label)
+end
+
+"""
+    GlobalLinearConstraint(name, A, b; label=...)
+
+Equality form `A·g = b`.
+"""
+function GlobalLinearConstraint(
+    name::Symbol,
+    A::AbstractMatrix,
+    b::AbstractVector;
+    label::String = "global linear equality on :$name",
+)
+    return GlobalLinearConstraint(name, A, b, b; label = label)
+end
+
+function Base.show(io::IO, c::GlobalLinearConstraint)
+    print(io, "GlobalLinearConstraint: \"$(c.label)\" ($(size(c.A,1)) rows on :$(c.name))")
+end
+
+# =========================================================================== #
+
+@testitem "GlobalLinearConstraint - equality relation g[1] = g[2]" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # one row: g[1] - g[2] = 0
+    A = spzeros(1, gdim); A[1, 1] = 1.0; A[1, 2] = -1.0
+    con = GlobalLinearConstraint(:g, A, [0.0])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test abs(g[1] - g[2]) < 1e-7
+end
+
+@testitem "GlobalLinearConstraint - two-sided inequality bound on a difference" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # -0.1 ≤ g[1] - g[2] ≤ 0.1
+    A = spzeros(1, gdim); A[1, 1] = 1.0; A[1, 2] = -1.0
+    con = GlobalLinearConstraint(:g, A, [-0.1], [0.1])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test g[1] - g[2] <= 0.1 + 1e-7
+    @test g[1] - g[2] >= -0.1 - 1e-7
+end

--- a/src/solvers/constrain.jl
+++ b/src/solvers/constrain.jl
@@ -347,13 +347,23 @@ function (con::GlobalLinearConstraint)(
     row_terms = [MOI.ScalarAffineTerm{Float64}[] for _ = 1:nrows]
     Is, Js, Vs = findnz(con.A)
     for (i, j, v) in zip(Is, Js, Vs)
-        push!(row_terms[i], MOI.ScalarAffineTerm(v, vars[base + g[j]]))
+        push!(row_terms[i], MOI.ScalarAffineTerm(v, vars[base+g[j]]))
     end
 
     for r = 1:nrows
-        isempty(row_terms[r]) && continue          # all-zero row → nothing to constrain
-        f = MOI.ScalarAffineFunction(row_terms[r], 0.0)
         lo, hi = con.lb[r], con.ub[r]
+        if isempty(row_terms[r])
+            # All-zero row: A[r,:]·g ≡ 0, so the row reduces to lo ≤ 0 ≤ hi.
+            # Feasible iff 0 ∈ [lo, hi] — then there is nothing to add. Otherwise
+            # the user specified a structurally infeasible row; surface it rather
+            # than silently dropping it.
+            lo <= 0 <= hi || error(
+                "GlobalLinearConstraint: row $r of A is all zeros, reducing to " *
+                "$lo ≤ 0 ≤ $hi, which is infeasible",
+            )
+            continue
+        end
+        f = MOI.ScalarAffineFunction(row_terms[r], 0.0)
         if lo == hi
             MOI.add_constraints(opt, f, MOI.EqualTo(lo))
         else

--- a/src/solvers/constrain.jl
+++ b/src/solvers/constrain.jl
@@ -1,6 +1,7 @@
 using DirectTrajOpt
 using NamedTrajectories
 using TrajectoryIndexingUtils
+using SparseArrays
 
 using DirectTrajOpt.Constraints
 
@@ -324,6 +325,43 @@ function (con::SymmetryConstraint)(
             MOI.EqualTo(0.0),
         )
     end
+end
+
+function (con::GlobalLinearConstraint)(
+    opt::AbstractOptimizer,
+    vars::Vector{MOI.VariableIndex},
+    traj::NamedTrajectory,
+)
+    haskey(traj.global_components, con.name) ||
+        error("GlobalLinearConstraint: global :$(con.name) not found in trajectory")
+    g = traj.global_components[con.name]          # indices within global_data
+    size(con.A, 2) == length(g) || error(
+        "GlobalLinearConstraint: A has $(size(con.A, 2)) columns but global " *
+        ":$(con.name) has dim $(length(g))",
+    )
+
+    base = traj.dim * traj.N                       # global vars follow the knot vars
+    nrows = size(con.A, 1)
+
+    # Bucket the sparse entries by row (CSC is column-major, so collect once).
+    row_terms = [MOI.ScalarAffineTerm{Float64}[] for _ = 1:nrows]
+    Is, Js, Vs = findnz(con.A)
+    for (i, j, v) in zip(Is, Js, Vs)
+        push!(row_terms[i], MOI.ScalarAffineTerm(v, vars[base + g[j]]))
+    end
+
+    for r = 1:nrows
+        isempty(row_terms[r]) && continue          # all-zero row → nothing to constrain
+        f = MOI.ScalarAffineFunction(row_terms[r], 0.0)
+        lo, hi = con.lb[r], con.ub[r]
+        if lo == hi
+            MOI.add_constraints(opt, f, MOI.EqualTo(lo))
+        else
+            isfinite(lo) && MOI.add_constraints(opt, f, MOI.GreaterThan(lo))
+            isfinite(hi) && MOI.add_constraints(opt, f, MOI.LessThan(hi))
+        end
+    end
+    return nothing
 end
 
 function (con::TimeConsistencyConstraint)(


### PR DESCRIPTION
## Summary

Adds `GlobalLinearConstraint{name, A, lb, ub}`, enforcing `lb ≤ A·g ≤ ub` over a global variable block `g`. Each row of `A` becomes a `ScalarAffineFunction` row — an `EqualTo` when `lb[r] == ub[r]`, otherwise the finite-sided `GreaterThan`/`LessThan` (skipping `±Inf`).

## Why

There was no way to express a **relation or bound on a linear combination / subset of a global block**. The existing constraints only pin the *whole* block to values:
- `BoundsConstraint` on a global ignores `subcomponents` and bounds the entire block.
- `GlobalEqualityConstraint` pins the entire block to a value vector.

`GlobalLinearConstraint` fills that gap. Follows the existing `AbstractLinearConstraint` pattern (callable `(con)(opt, vars, traj)` adding MOI rows; resolves indices at apply-time).

### Motivating use
A B-spline **slew bound** `|c_{i+1} − c_i| ≤ vₘₐₓ` — a linear inequality on differences of the control-point global block — and other control-point relations. (Variable *fixing*, e.g. an endpoint-value pin, should still use bounds, not this; equality-constraining a to-be-fixed variable makes Ipopt oscillate.)

## Tests

Two `@testitem`s, validated end-to-end through the solver:
- equality relation `g[1] = g[2]` → satisfied to <1e-7
- two-sided inequality `-0.1 ≤ g[1] − g[2] ≤ 0.1` → respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)