### PR TITLE
Merge remote-tracking branch 'origin/main' into feat/matrix-free-obj-constr (fixing clobbered workflow updates)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
           # behavior to 1.12 (where dependabot can actually exercise the new bound).
           force_latest_compatible_version: ${{ matrix.version == '1.12' && 'auto' || 'false' }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/alloc-profile.yml
+++ b/.github/workflows/alloc-profile.yml
@@ -34,12 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.12'
           arch: x64
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
 
       - name: Instantiate benchmark environment
         run: julia --project=benchmark -e 'using Pkg; Pkg.instantiate()'
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload alloc-profile artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: alloc-profile-${{ github.event.pull_request.number || github.ref_name }}-${{ github.sha }}
           path: benchmark/results/allocs/

--- a/.github/workflows/benchmark-convergence.yml
+++ b/.github/workflows/benchmark-convergence.yml
@@ -28,12 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.12'
           arch: x64
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
 
       - name: Instantiate convergence environment
         run: julia --project=benchmark/convergence -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload convergence artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: convergence-${{ github.event.pull_request.number || github.ref_name }}-${{ github.sha }}
           path: benchmark/convergence/results/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,12 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.12'
           arch: x64
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
 
       - name: Instantiate benchmark environment
         run: julia --project=benchmark -e 'using Pkg; Pkg.instantiate()'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload benchmark artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-${{ github.event.pull_request.number || github.ref_name }}-${{ github.sha }}
           path: benchmark/results/

--- a/src/constraints/_constraints.jl
+++ b/src/constraints/_constraints.jl
@@ -247,6 +247,7 @@ include("linear/total_constraint.jl")
 include("linear/symmetry_constraint.jl")
 include("linear/time_consistency_constraint.jl")
 include("linear/l1_slack_constraint.jl")
+include("linear/global_linear_constraint.jl")
 
 # Nonlinear constraints
 include("nonlinear/knot_point_constraint.jl")

--- a/src/constraints/linear/global_linear_constraint.jl
+++ b/src/constraints/linear/global_linear_constraint.jl
@@ -1,0 +1,250 @@
+export GlobalLinearConstraint
+
+using SparseArrays
+
+"""
+    struct GlobalLinearConstraint <: AbstractLinearConstraint
+
+A general linear constraint on a global variable block: `lb ≤ A·g ≤ ub`, where
+`g` is the global block named `name` (length = number of columns of `A`). Each
+row of `A` becomes one affine row over the global variables; rows with
+`lb[r] == ub[r]` are emitted as equalities (`MOI.EqualTo`), otherwise as the
+finite-sided bounds (`GreaterThan`/`LessThan`, skipping `±Inf`).
+
+This is the primitive for relations and bounds on *subcomponents* of a global
+block — which the per-variable `BoundsConstraint`/`GlobalEqualityConstraint`
+cannot express (they pin the whole block to values, not linear combinations of
+its slots). Typical uses: pin a B-spline endpoint *derivative*
+(`c₁ − c₀ = 0`, an equality relation) or bound a B-spline slew
+(`|c_{i+1} − c_i| ≤ vₘₐₓ`, a two-sided inequality).
+
+# Fields
+- `name::Symbol`: global block to constrain (a key of `traj.global_components`)
+- `A::SparseMatrixCSC{Float64,Int}`: `(n_rows × global_dim)` coefficient matrix
+- `lb::Vector{Float64}`, `ub::Vector{Float64}`: per-row bounds (length `n_rows`)
+- `label::String`
+"""
+struct GlobalLinearConstraint <: AbstractLinearConstraint
+    name::Symbol
+    A::SparseMatrixCSC{Float64,Int}
+    lb::Vector{Float64}
+    ub::Vector{Float64}
+    label::String
+end
+
+"""
+    GlobalLinearConstraint(name, A, lb, ub; label=...)
+
+Inequality form `lb ≤ A·g ≤ ub`. `A` may be any `AbstractMatrix` (stored sparse).
+"""
+function GlobalLinearConstraint(
+    name::Symbol,
+    A::AbstractMatrix,
+    lb::AbstractVector,
+    ub::AbstractVector;
+    label::String = "global linear constraint on :$name",
+)
+    # Preserve sparsity (don't densify a banded slew-bound A): convert straight
+    # to CSC. SparseArrays.sparse on a dense Matrix would be O(rows×cols).
+    As = convert(SparseMatrixCSC{Float64,Int}, A)
+    size(As, 1) == length(lb) == length(ub) || throw(
+        ArgumentError(
+            "row count mismatch: A has $(size(As,1)) rows, lb has $(length(lb)), ub has $(length(ub))",
+        ),
+    )
+    all(lb .<= ub) || throw(ArgumentError("lb must be elementwise ≤ ub"))
+    return GlobalLinearConstraint(name, As, Vector{Float64}(lb), Vector{Float64}(ub), label)
+end
+
+"""
+    GlobalLinearConstraint(name, A, b; label=...)
+
+Equality form `A·g = b`.
+"""
+function GlobalLinearConstraint(
+    name::Symbol,
+    A::AbstractMatrix,
+    b::AbstractVector;
+    label::String = "global linear equality on :$name",
+)
+    return GlobalLinearConstraint(name, A, b, b; label = label)
+end
+
+function Base.show(io::IO, c::GlobalLinearConstraint)
+    print(io, "GlobalLinearConstraint: \"$(c.label)\" ($(size(c.A,1)) rows on :$(c.name))")
+end
+
+# =========================================================================== #
+
+@testitem "GlobalLinearConstraint - equality relation g[1] = g[2]" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # one row: g[1] - g[2] = 0
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = -1.0
+    con = GlobalLinearConstraint(:g, A, [0.0])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test abs(g[1] - g[2]) < 1e-7
+end
+
+@testitem "GlobalLinearConstraint - two-sided inequality bound on a difference" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # -0.1 ≤ g[1] - g[2] ≤ 0.1
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = -1.0
+    con = GlobalLinearConstraint(:g, A, [-0.1], [0.1])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test g[1] - g[2] <= 0.1 + 1e-7
+    @test g[1] - g[2] >= -0.1 - 1e-7
+end
+
+@testitem "GlobalLinearConstraint - infeasible all-zero row is surfaced" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # All-zero row reduces to 1 ≤ 0·g ≤ 2, i.e. 1 ≤ 0 ≤ 2 — infeasible.
+    A = spzeros(1, gdim)
+    con = GlobalLinearConstraint(:g, A, [1.0], [2.0])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    @test_throws ErrorException solve!(prob; max_iter = 1)
+end
+
+@testitem "GlobalLinearConstraint - multi-row banded slew bound" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # Banded first-difference operator: |g[i+1] - g[i]| ≤ vmax for all i.
+    nrows = gdim - 1
+    A = spzeros(nrows, gdim)
+    for i = 1:nrows
+        A[i, i] = -1.0
+        A[i, i+1] = 1.0
+    end
+    vmax = 0.5
+    con = GlobalLinearConstraint(:g, A, fill(-vmax, nrows), fill(vmax, nrows))
+    # The conversion must keep A sparse (not densify it).
+    @test con.A isa SparseMatrixCSC{Float64,Int}
+    @test nnz(con.A) == 2nrows
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test all(abs.(diff(g)) .<= vmax + 1e-7)
+end
+
+@testitem "GlobalLinearConstraint - one-sided (Inf) bound" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # Only a lower bound: g[1] - g[2] ≥ 0.2, upper side is +Inf (must be skipped,
+    # emitting a lone GreaterThan and no LessThan).
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = -1.0
+    con = GlobalLinearConstraint(:g, A, [0.2], [Inf])
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test g[1] - g[2] >= 0.2 - 1e-7
+end
+
+@testitem "GlobalLinearConstraint - equality overload A·g = b" begin
+    using SparseArrays
+    include("../../../test/test_utils.jl")
+
+    G, traj = bilinear_dynamics_and_trajectory(add_global = true)
+    integrators = [
+        BilinearIntegrator(G, :x, :u, traj),
+        DerivativeIntegrator(:u, :du, traj),
+        DerivativeIntegrator(:du, :ddu, traj),
+    ]
+    J = TerminalObjective(x -> norm(x - traj.goal.x)^2, :x, traj)
+    J += QuadraticRegularizer(:u, traj, 1.0)
+    J += MinimumTimeObjective(traj)
+
+    gdim = length(traj.global_components[:g])
+    # Two-arg equality form: g[1] + g[2] = 1.0.
+    A = spzeros(1, gdim);
+    A[1, 1] = 1.0;
+    A[1, 2] = 1.0
+    con = GlobalLinearConstraint(:g, A, [1.0])
+    @test con.lb == con.ub == [1.0]
+
+    prob = DirectTrajOptProblem(traj, J, integrators; constraints = [con])
+    solve!(prob; max_iter = 100)
+
+    g = prob.trajectory.global_data[traj.global_components[:g]]
+    @test abs(g[1] + g[2] - 1.0) < 1e-7
+end

--- a/src/solvers/constrain.jl
+++ b/src/solvers/constrain.jl
@@ -1,6 +1,7 @@
 using DirectTrajOpt
 using NamedTrajectories
 using TrajectoryIndexingUtils
+using SparseArrays
 
 using DirectTrajOpt.Constraints
 
@@ -324,6 +325,53 @@ function (con::SymmetryConstraint)(
             MOI.EqualTo(0.0),
         )
     end
+end
+
+function (con::GlobalLinearConstraint)(
+    opt::AbstractOptimizer,
+    vars::Vector{MOI.VariableIndex},
+    traj::NamedTrajectory,
+)
+    haskey(traj.global_components, con.name) ||
+        error("GlobalLinearConstraint: global :$(con.name) not found in trajectory")
+    g = traj.global_components[con.name]          # indices within global_data
+    size(con.A, 2) == length(g) || error(
+        "GlobalLinearConstraint: A has $(size(con.A, 2)) columns but global " *
+        ":$(con.name) has dim $(length(g))",
+    )
+
+    base = traj.dim * traj.N                       # global vars follow the knot vars
+    nrows = size(con.A, 1)
+
+    # Bucket the sparse entries by row (CSC is column-major, so collect once).
+    row_terms = [MOI.ScalarAffineTerm{Float64}[] for _ = 1:nrows]
+    Is, Js, Vs = findnz(con.A)
+    for (i, j, v) in zip(Is, Js, Vs)
+        push!(row_terms[i], MOI.ScalarAffineTerm(v, vars[base+g[j]]))
+    end
+
+    for r = 1:nrows
+        lo, hi = con.lb[r], con.ub[r]
+        if isempty(row_terms[r])
+            # All-zero row: A[r,:]·g ≡ 0, so the row reduces to lo ≤ 0 ≤ hi.
+            # Feasible iff 0 ∈ [lo, hi] — then there is nothing to add. Otherwise
+            # the user specified a structurally infeasible row; surface it rather
+            # than silently dropping it.
+            lo <= 0 <= hi || error(
+                "GlobalLinearConstraint: row $r of A is all zeros, reducing to " *
+                "$lo ≤ 0 ≤ $hi, which is infeasible",
+            )
+            continue
+        end
+        f = MOI.ScalarAffineFunction(row_terms[r], 0.0)
+        if lo == hi
+            MOI.add_constraints(opt, f, MOI.EqualTo(lo))
+        else
+            isfinite(lo) && MOI.add_constraints(opt, f, MOI.GreaterThan(lo))
+            isfinite(hi) && MOI.add_constraints(opt, f, MOI.LessThan(hi))
+        end
+    end
+    return nothing
 end
 
 function (con::TimeConsistencyConstraint)(


### PR DESCRIPTION
# DTO Issue #113 implementation summary (v1)                                                                                           
                                                                                                                                       
**Status:** Implemented and tested on 2026-06-30 against                                                                               
`DirectTrajOpt.jl@feat/matrix-free-obj-constr`. **Not yet committed.**                                                                 
Test log archived at [`../../tmp/knot_hvp_run1.log`](../../tmp/knot_hvp_run1.log).                                                     
                                                                                                                                       
**Companion artifacts:**                                                                                                               
[`./dto-matrix-free.md`](./dto-matrix-free.md) — original design doc;                                                                  
this summary covers Interface A (`KnotHVP`) only.                                                                                      

---

## Test results

| Test | Pass | Total |
|---|---:|---:|
| trait defaults to nothing for every objective | 6 | 6 |
| ConstantLowRankHVP round-trips via KnotPointObjective | 3 | 3 |
| CustomKnotHVP round-trips via KnotPointObjective | 4 | 4 |
| TerminalObjective threads knot_hvp keyword | 2 | 2 |
| default field value is nothing (no-regression smoke) | 7 | 7 |
| **Total** | **22** | **22** |

Wall time 4.1s; no warnings, no errors.
                                                                                                                     17:41:42 [39/1898]
- **NEW** `src/objectives/knot_hvp.jl` — `KnotHVP` abstract,
  `ConstantLowRankHVP(A::Matrix{Float64}, core::Symbol)`,
  `CustomKnotHVP(apply!::Function, on_device::Bool)`, generic
  `knot_hvp(::AbstractObjective, ::NamedTrajectory) = nothing`, and the
  5 inline `@testitem` blocks.
- `src/objectives/_objectives.jl` — exports of `KnotHVP`,
  `ConstantLowRankHVP`, `CustomKnotHVP`, `knot_hvp` (4 lines), and
  `include("knot_hvp.jl")` placed **before** `knot_point_objectives.jl`
  so `KnotHVP` is in scope when the struct's field type is parsed.
- `src/objectives/knot_point_objectives.jl` — added
  `knot_hvp::Union{Nothing,KnotHVP}` field to the struct,
  `knot_hvp=nothing` keyword on the canonical outer constructor
  (Outer 1 at `:68`), threaded through to the inner. The other three
  outer constructors and both `TerminalObjective` variants forward
  `kwargs...` so they pick up the keyword automatically. Added the
  trait specialization
  `knot_hvp(obj::KnotPointObjective, ::NamedTrajectory) = obj.knot_hvp`
  next to `Base.show`. Docstring updated to replace the phantom
  `∂²Ls` line (a doc artifact from the `6aeceee` refactor — never an
  actual field) with the real `knot_hvp` field description.

---

## Acceptance criteria (issue #113)
                                                                                                                                       
- [x] `KnotHVP`, `ConstantLowRankHVP`, `CustomKnotHVP` defined beside                                                                  
  `get_full_hessian`.                                                                                                                  
- [x] Optional `knot_hvp::Union{Nothing,KnotHVP} = nothing` on                                                                         
  `KnotPointObjective`; threaded through `TerminalObjective` via
  `kwargs...`.
- [x] Trait with generic default + `KnotPointObjective` specialization.
- [x] Docstrings define the contract: data layout, `core` symbol
  convention, `apply!` signature, `on_device` host-staging semantics.
- [x] Default returns `nothing` for every current objective type (T1
  covers `KnotPointObjective`, `QuadraticRegularizer`,
  `MinimumTimeObjective`, `GlobalObjective`, `CompositeObjective`,
  `NullObjective`).
- [ ] Minor release bump (`v0.9.6 → v0.9.7` per semver, additive) —
  not done in this turn; flag for the commit step.

---

## Out of scope (carried forward) 

The remaining items from
[`./dto-matrix-free.md`](./dto-matrix-free.md) and
[`./piccolissimo-matrix-free.md`](./piccolissimo-matrix-free.md) remain
unstarted:

1. **Piccolissimo Issue #179** — consume `knot_hvp(obj, traj)` in the
   Altissimo backend; sunset PR #178's per-iterate probe+SVD for
   Tier-1 objectives. Blocked on this PR + compat bump.
2. **DTO `StepHVP` capability** — sibling interface for the
   integrator-side constraint-curvature HVP. Independent of #113;
   release-decoupled.
3. **Altissimo backend wiring** —
   `AltissimoOptions.constraint_curvature_hvp` flag + closure
   dispatched on `step_hvp_capability`.
4. **Phase 3 — GPU device-path constraint HVP** — the big lift,
   in-scope per prior decision.

Full DTO no-regression sweep also deferred per prior
compute-conservation guidance.
