### PR TITLE
chore: bump version to 0.9.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DirectTrajOpt"
 uuid = "c823fa1f-8872-4af5-b810-2b9b72bbbf56"
-version = "0.9.8"
+version = "0.9.7"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Corrects the version bump from PR #114 (0.9.8) down to 0.9.7 — 0.9.7 was already burned transiently in Project.toml during the KnotHVP revert/re-land churn but never tagged or released, so this release fills that slot instead of leaving a gap.