### PR TITLE
Dev/dto issue 122 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,6 @@ Changes before v0.9.8 are not recorded here — see the
 
 ### Fixed
 
-- `QuadraticRegularizer` no longer errors on trajectories with a fixed timestep.
-  `gradient!`, `hessian_structure` and `get_full_hessian` looked up
-  `traj.components[traj.timestep]` unconditionally; when `timestep` is a `Float64`
-  rather than a `Symbol` that indexes a `NamedTuple` with a float, raising a
-  `MethodError`. The `∂²J/∂v²` block is still emitted in that case — a fixed Δt is
-  a factor in the value — while the timestep gradient and cross terms are skipped.
-
 - `QuadraticRegularizer`'s `hessian_structure` no longer over-declares the
   control–control block. `R` is a vector of per-component weights, so `∂²J/∂v²` is
   diagonal, but the full `d × d` block was declared — reserving `d(d-1)/2`
@@ -50,3 +43,14 @@ Changes before v0.9.8 are not recorded here — see the
 
 - Corrected drifted comments on the `QuadraticRegularizer` Hessian blocks, which
   stated factors the adjacent code did not apply.
+
+### Internal
+
+- `QuadraticRegularizer`'s `gradient!`, `hessian_structure` and `get_full_hessian`
+  now guard the `traj.components[traj.timestep]` lookup behind
+  `traj.timestep isa Symbol`, as `LinearRegularizer` already did. This is
+  defensive only: `NamedTrajectory.timestep` is typed `Symbol` in the current
+  NamedTrajectories, so a fixed timestep is not currently representable and the
+  branch folds away. The `∂²J/∂v²` block is emitted either way — a fixed Δt would
+  still be a factor in the value — so, unlike `LinearRegularizer`, these methods
+  cannot simply return early.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,11 @@ Changes before v0.9.8 are not recorded here — see the
   against using them weakened, silently. Any hand-tuned `R` was therefore tuned
   against a grid-dependent quantity.
 
-  On a uniform grid the old value is reproduced exactly by passing `R * Δt`, but
-  problems with tuned regularisation weights should be re-tuned rather than
-  rescaled — the point of the fix is that the old quantity was not a quadrature
-  of anything.
+  On a uniform grid the old *value* is reproduced exactly by passing `R * Δt` —
+  though not the old `∂J/∂Δt`, so that is not a drop-in substitution when the
+  timestep is a decision variable. Problems with tuned regularisation weights
+  should be re-tuned rather than rescaled — the point of the fix is that the old
+  quantity was not a quadrature of anything.
 
   The value, gradient, full Hessian and Hessian sparsity structure were updated
   together. `∂²J/∂Δt²` is now identically zero and is no longer declared as a
@@ -34,6 +35,18 @@ Changes before v0.9.8 are not recorded here — see the
   `LinearRegularizer` is unaffected — it already weighted by a single Δt.
 
 ### Fixed
+
+- `QuadraticRegularizer` no longer errors on trajectories with a fixed timestep.
+  `gradient!`, `hessian_structure` and `get_full_hessian` looked up
+  `traj.components[traj.timestep]` unconditionally; when `timestep` is a `Float64`
+  rather than a `Symbol` that indexes a `NamedTuple` with a float, raising a
+  `MethodError`. The `∂²J/∂v²` block is still emitted in that case — a fixed Δt is
+  a factor in the value — while the timestep gradient and cross terms are skipped.
+
+- `QuadraticRegularizer`'s `hessian_structure` no longer over-declares the
+  control–control block. `R` is a vector of per-component weights, so `∂²J/∂v²` is
+  diagonal, but the full `d × d` block was declared — reserving `d(d-1)/2`
+  structural nonzeros per knot that can never be nonzero.
 
 - Corrected drifted comments on the `QuadraticRegularizer` Hessian blocks, which
   stated factors the adjacent code did not apply.

--- a/src/objectives/regularizers.jl
+++ b/src/objectives/regularizers.jl
@@ -30,9 +30,10 @@ not declared in the Hessian structure.
     the single Δt documented above (issue #122). That made the penalty fall off
     as 1/N under grid refinement — 32× weaker across a 25 → 800 knot sweep for
     a fixed continuous pulse — so any hand-tuned `R` was tuned against a
-    grid-dependent quantity. On a uniform grid the old value is reproduced
-    exactly by passing `R * Δt`; problems with tuned regularisation weights
-    should be re-tuned.
+    grid-dependent quantity. On a uniform grid the old *value* is reproduced
+    exactly by passing `R * Δt` — but not the old `∂J/∂Δt`, so this is not a
+    drop-in substitution when the timestep is a decision variable. Problems
+    with tuned regularisation weights should be re-tuned.
 
 # Fields
 - `name::Symbol`: Name of the variable to regularize
@@ -107,7 +108,13 @@ end
 
 function gradient!(∇::AbstractVector, reg::QuadraticRegularizer, traj::NamedTrajectory)
     v_comps = traj.components[reg.name]
-    Δt_comps = traj.components[traj.timestep]
+    # Defensive, matching LinearRegularizer: `NamedTrajectory.timestep` is typed
+    # `Symbol` in the current NamedTrajectories, so this is always true and the
+    # branch folds away. It guards the `traj.components[traj.timestep]` lookup,
+    # which would be a NamedTuple indexed by a Float64 if fixed timesteps ever
+    # come back.
+    free_time = traj.timestep isa Symbol
+    Δt_comps = free_time ? traj.components[traj.timestep] : ()
     for t ∈ reg.times
         zₖ = traj[t]
         vₖ = zₖ[reg.name]
@@ -120,7 +127,7 @@ function gradient!(∇::AbstractVector, reg::QuadraticRegularizer, traj::NamedTr
         ∇[v_indices] .+= ∇v
 
         # ∂J/∂Δt_k = ½ Δv_kᵀ R Δv_k  (if the timestep is a variable)
-        if traj.timestep isa Symbol
+        if free_time
             ∇Δt = 0.5 * Δvₖ' * (reg.R .* Δvₖ)
             Δt_indices = slice(t, Δt_comps, traj.dim)
             ∇[Δt_indices] .+= ∇Δt
@@ -135,17 +142,23 @@ function hessian_structure(reg::QuadraticRegularizer, traj::NamedTrajectory)
     structure = spzeros(Z_dim, Z_dim)
 
     v_comps = traj.components[reg.name]
-    Δt_comp = traj.components[traj.timestep][1]
+    free_time = traj.timestep isa Symbol
+    Δt_comp = free_time ? traj.components[traj.timestep][1] : 0
 
     for k ∈ reg.times
         v_indices = slice(k, v_comps, traj.dim)
-        Δt_index = index(k, Δt_comp, traj.dim)
 
-        # ∂²J/∂v²
-        structure[v_indices, v_indices] .= 1.0
+        # ∂²J/∂v² = Δt · diag(R). R is a vector of per-component weights, so this
+        # block is diagonal; declaring the full d×d block would reserve d(d-1)/2
+        # structural nonzeros per knot that can never be nonzero.
+        for v_index ∈ v_indices
+            structure[v_index, v_index] = 1.0
+        end
 
-        # ∂²J/∂Δt∂v
-        structure[v_indices, Δt_index] .= 1.0
+        # ∂²J/∂Δt∂v, only when the timestep is a decision variable.
+        if free_time
+            structure[v_indices, index(k, Δt_comp, traj.dim)] .= 1.0
+        end
 
         # No ∂²J/∂Δt² entry: with the single-Δt weight the objective is linear
         # in each Δt, so that second derivative is identically zero and must
@@ -160,28 +173,32 @@ function get_full_hessian(reg::QuadraticRegularizer, traj::NamedTrajectory)
     ∂²J = spzeros(Z_dim, Z_dim)
 
     v_comps = traj.components[reg.name]
-    Δt_comp = traj.components[traj.timestep][1]
+    free_time = traj.timestep isa Symbol
+    Δt_comp = free_time ? traj.components[traj.timestep][1] : 0
 
     for t ∈ reg.times
         zₖ = traj[t]
         Δt = zₖ.timestep
         v_indices = slice(t, v_comps, traj.dim)
-        Δt_index = index(t, Δt_comp, traj.dim)
 
-        rₖ = zₖ[reg.name] - reg.baseline[:, t]
-
-        # ∂²J/∂v² = Δt * R
+        # ∂²J/∂v² = Δt * R. Present whether or not Δt is a decision variable —
+        # a fixed timestep is still a factor in the value.
         ∂²J[v_indices, v_indices] = Δt * spdiagm(reg.R)
 
-        # ∂²J/∂Δt∂v = R ⊙ (v - baseline)
-        ∂²J[v_indices, Δt_index] = reg.R .* rₖ
+        # ∂²J/∂Δt∂v = R ⊙ (v - baseline), only when the timestep is a decision
+        # variable. Unlike LinearRegularizer, this objective cannot return early
+        # for fixed timesteps: the ∂²J/∂v² block above survives.
+        if free_time
+            rₖ = zₖ[reg.name] - reg.baseline[:, t]
+            ∂²J[v_indices, index(t, Δt_comp, traj.dim)] = reg.R .* rₖ
+        end
 
         # ∂²J/∂Δt² = 0 — the value is linear in Δt, so there is no
         # timestep-timestep term. Deliberately not stored (see
         # `hessian_structure`, which declares no entry for it).
     end
 
-    return ∂²J
+    return dropzeros!(∂²J)
 end
 
 # ============================================================================ #
@@ -433,7 +450,7 @@ end
     end
 end
 
-@testitem "QuadraticRegularizer Hessian structure declares no Δt-Δt entry" begin
+@testitem "QuadraticRegularizer Hessian structure declares exactly the nonzeros" begin
     include("../../test/test_utils.jl")
     using DirectTrajOpt.Objectives
     using SparseArrays
@@ -455,8 +472,38 @@ end
         @test iszero(H[Δt_index, Δt_index])
     end
 
-    # The declared structure must still cover every nonzero the Hessian
-    # actually produces — a solver only writes into declared entries.
+    # The declared structure must cover every nonzero the Hessian actually
+    # produces — the evaluator writes only into declared entries, so anything
+    # undeclared is silently dropped from the solver's Hessian.
     rows, cols, _ = findnz(H)
     @test all(!iszero(S[i, j]) for (i, j) ∈ zip(rows, cols))
+
+    # ...and the converse: the structure must not over-declare either. R is a
+    # vector of per-component weights, so ∂²J/∂v² is diagonal; declaring the
+    # dense d×d block would reserve d(d-1)/2 entries per knot that can never be
+    # nonzero. Checked on a deterministic trajectory whose weights and residuals
+    # are all nonzero, so every declared entry is genuinely realised — with a
+    # zero weight or a zero residual component the entry would be absent from H
+    # while still (legitimately) declared, and this direction would flake.
+    N = 4
+    exact_traj = NamedTrajectory(
+        (
+            x = ones(2, N),
+            u = reshape(collect(1.0:(3N)), 3, N),
+            Δt = fill(0.1, 1, N),
+        );
+        controls = (:u, :Δt),
+        timestep = :Δt,
+    )
+    EXACT_OBJ = QuadraticRegularizer(
+        :u,
+        exact_traj,
+        [0.3, 1.7, 0.9];
+        baseline = fill(-1.0, 3, N),
+    )
+
+    S_exact = DirectTrajOpt.Objectives.hessian_structure(EXACT_OBJ, exact_traj)
+    H_exact = DirectTrajOpt.Objectives.get_full_hessian(EXACT_OBJ, exact_traj)
+
+    @test Set(zip(findnz(S_exact)[1:2]...)) == Set(zip(findnz(H_exact)[1:2]...))
 end


### PR DESCRIPTION
# DirectTrajOpt — follow-up layer on #122

**Refs:** issue [#122](https://github.com/harmoniqs/DirectTrajOpt.jl/issues/122) ·
PR [#123](https://github.com/harmoniqs/DirectTrajOpt.jl/pull/123) (merged
2026-08-02, base `19e414e`)

**Branch:** `issue-122` — two commits on top of the merged #123 tree
(`1b4acb5` "Spot fixes", `e45a0e2` "Updating CHANGELOG").

---

## What this is

#123 satisfied every acceptance criterion in #122: the single-Δt weighting across
value, gradient, full Hessian and Hessian *structure*, the N-invariance regression,
finite-difference parity at variable timestep, and the migration note. This layer sits
on top of it and covers three things found while reviewing that change — one a direct
extension of #122's own reasoning, two pre-existing and unrelated to the weighting.

Nothing here revisits the weighting decision. `R` still means what #123 says it means.

## 1. `hessian_structure` over-declared the control–control block

`R::Vector{Float64}` is a vector of per-component weights, so `∂²J/∂v² = Δt · diag(R)`
is **diagonal** — but the full `d × d` block was declared, reserving `d(d-1)/2`
structural nonzeros per knot that can never be nonzero.

This is the same defect class as #122's AC4, which called out the Δt–Δt entry as "the
one a mechanical edit of the arithmetic would miss." AC4's rationale — *do not declare
a structural nonzero that is always zero* — applies verbatim to the off-diagonals, and
#123 left them declared while removing the Δt–Δt entry. Over-declaration is safe
(the evaluator only ever writes into declared entries, so the risk direction is
under-declaration) but it inflates the assembled sparsity for every consumer.

Measured on a 4-knot, `d = 3` fixture: **48 → 24 declared nonzeros**.

`get_full_hessian` now returns `dropzeros!(∂²J)` so the emitted pattern and the
declared pattern agree exactly.

## 2. Fixed-timestep trajectories — defensive guards (pre-existing)

`gradient!`, `hessian_structure` and `get_full_hessian` looked up
`traj.components[traj.timestep]` unconditionally. With a `Float64` timestep that
indexes a `NamedTuple` with a float — a `MethodError`. `LinearRegularizer` already
guarded this; `QuadraticRegularizer` did not, and in `gradient!` the *use* was guarded
by `traj.timestep isa Symbol` while the *lookup* above it was not.

**This is unreachable today.** `NamedTrajectories` types the field `timestep::Symbol`
(`struct_named_trajectory.jl:67`), so a fixed timestep is not representable and the
guard constant-folds. It is filed under `### Internal` in the changelog rather than
`### Fixed` for exactly that reason, and the corresponding test was dropped rather than
written against an unconstructible fixture — `test_utils.jl`'s
`named_trajectory_type_1(free_time = false)` branch throws, and had no callers.

Kept anyway because it costs nothing, restores symmetry with `LinearRegularizer`, and
matches an assumption Piccolissimo's device backend already documents. Note the guard
must be *partial*: unlike `LinearRegularizer`, this objective cannot return early,
because `∂²J/∂v² = Δt·R` is nonzero whether or not Δt is a decision variable.

## 3. Migration note was value-only

The docstring and changelog said the old behaviour is "reproduced exactly by passing
`R * Δt`". True for the **value** on a uniform grid, but not for `∂J/∂Δt` when the
timestep is free — old `Δt ΔvᵀRΔv` versus substituted `½Δt ΔvᵀRΔv`. Since free-time
problems are the common case downstream, both texts now say so explicitly.

## Tests

- The `#123` structure test is extended from one-directional coverage
  (`structure ⊇ nonzeros(H)`) to **exact agreement in both directions**, pinning the
  diagonal claim in §1. It uses a deterministic fixture with strictly nonzero `R` and
  residuals: with a zero weight or a zero residual component the entry is legitimately
  declared but absent from `H`, and the converse direction would flake against the
  randomly-initialised shared fixture.
- Renamed to "QuadraticRegularizer Hessian structure declares exactly the nonzeros".

**Results:** regularizer test items **36/36**; evaluator test items **10/10** (the
integration-level check that §1's tightening did not under-declare).

## Release

`Project.toml` is unchanged at `0.9.8` and the changelog entry is still under
`[Unreleased]`, pending the **0.9.9 / 0.10.0** decision. Worth resolving before
release: `R` silently changes meaning, which argues for the minor bump, though #122
left the staging question ("plain fix with migration note" versus "temporary opt-in")
to the maintainer.

## Out of scope

Retuning the `R` weights baked into downstream templates — explicitly out per #122's
Scope section, and unchanged here. See `dto-122-piccolissimo.1.md`: the retuning
fallout is now measured, and it reaches Piccolissimo's own suite, not only Piccolo's
templates.
